### PR TITLE
preliminary REQ-11 (DES-IDME) changes (client naming)

### DIFF
--- a/contrib/gitian-descriptors/gitian-osx-signer.yml
+++ b/contrib/gitian-descriptors/gitian-osx-signer.yml
@@ -33,5 +33,8 @@ script: |
 
   tar -xf ${UNSIGNED}
   ./detached-sig-apply.sh ${UNSIGNED} signature/osx
-  ${WRAP_DIR}/genisoimage -no-cache-inodes -D -l -probe -V "Bitcoin-Unlimited" -no-pad -r -apple -o uncompressed.dmg signed-app
+  # // MVF-BU begin change client name (MVHF-BU-DES-IDME-6)
+  # // MVF-BU included fix for diskimages needing 0755 folder permissions (Core:83d6d2870fb25fc25ce20b2288a124d937bbcc69)
+  ${WRAP_DIR}/genisoimage -no-cache-inodes -D -l -probe -V "Bitcoin-MVF-BU" -no-pad -r -dir-mode 0755 -apple -o uncompressed.dmg signed-app
+  # // MVF-BU end
   ${WRAP_DIR}/dmg dmg uncompressed.dmg ${OUTDIR}/${SIGNED}

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -1,5 +1,5 @@
 ---
-name: "BitcoinUnlimited-osx-0.12.1"
+name: "Bitcoin-MVF-BU-osx-0.12.1"
 enable_cache: true
 suites:
 - "trusty"
@@ -23,7 +23,7 @@ packages:
 - "python"
 reference_datetime: "2016-01-01 00:00:00"
 remotes:
-- "url": "https://github.com/BitcoinUnlimited/BitcoinUnlimited.git"
+- "url": "https://github.com/BTCfork/hardfork_prototype_1_mvf-bu.git"
   "dir": "bitcoin"
 files:
 - "MacOSX10.9.sdk.tar.gz"
@@ -86,7 +86,7 @@ script: |
   ./autogen.sh
   ./configure --prefix=${BASEPREFIX}/`echo "${HOSTS}" | awk '{print $1;}'`
   make dist
-  SOURCEDIST=`echo bitcoinUnlimited-*.tar.gz`
+  SOURCEDIST=`echo bitcoinMVF-BU-*.tar.gz`
   DISTNAME=`echo ${SOURCEDIST} | sed 's/.tar.*//'`
 
   # Correct tar file order
@@ -123,7 +123,7 @@ script: |
     popd
 
     make deploy
-    ${WRAP_DIR}/dmg dmg Bitcoin-Unlimited.dmg ${OUTDIR}/${DISTNAME}-osx-unsigned.dmg
+    ${WRAP_DIR}/dmg dmg Bitcoin-MVF-BU.dmg ${OUTDIR}/${DISTNAME}-osx-unsigned.dmg
 
     cd installed
     find . -name "lib*.la" -delete

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -86,7 +86,9 @@ script: |
   ./autogen.sh
   ./configure --prefix=${BASEPREFIX}/`echo "${HOSTS}" | awk '{print $1;}'`
   make dist
+  # MVF-BU begin change client name in filename (MVHF-BU-DES-IDME-6)
   SOURCEDIST=`echo bitcoinMVF-BU-*.tar.gz`
+  # MVF-BU end
   DISTNAME=`echo ${SOURCEDIST} | sed 's/.tar.*//'`
 
   # Correct tar file order
@@ -123,7 +125,9 @@ script: |
     popd
 
     make deploy
+    # MVF-BU begin change client name in filename (MVHF-BU-DES-IDME-6)
     ${WRAP_DIR}/dmg dmg Bitcoin-MVF-BU.dmg ${OUTDIR}/${DISTNAME}-osx-unsigned.dmg
+    # MVF-BU end
 
     cd installed
     find . -name "lib*.la" -delete

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2015 The Bitcoin Core developers
 // Copyright (c) 2015-2016 The Bitcoin Unlimited developers
+// Copyright (c) 2016 The Bitcoin developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -70,11 +70,11 @@ static bool AppInitRPC(int argc, char* argv[])
     //
     ParseParameters(argc, argv);
     if (argc<2 || mapArgs.count("-?") || mapArgs.count("-h") || mapArgs.count("-help") || mapArgs.count("-version")) {
-        // BU remove branding
-        std::string strUsage = _("Bitcoin RPC client version") + " " + FormatFullVersion() + "\n";
+
+        std::string strUsage = _("Bitcoin MVF-BU RPC client version") + " " + FormatFullVersion() + "\n";  // MVF-BU client name (MVHF-BU-DES-IDME-1)
         if (!mapArgs.count("-version")) {
             strUsage += "\n" + _("Usage:") + "\n" +
-                  "  bitcoin-cli [options] <command> [params]  " + _("Send command to Bitcoin") + "\n" +
+                  "  bitcoin-cli [options] <command> [params]  " + _("Send command to Bitcoin") + "\n" +   // BU remove branding
                   "  bitcoin-cli [options] help                " + _("List commands") + "\n" +
                   "  bitcoin-cli [options] help <command>      " + _("Get help for a command") + "\n";
 

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2009-2015 The Bitcoin developers
+// Copyright (c) 2009-2016 The Bitcoin developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -47,7 +47,7 @@ static bool AppInitRawTx(int argc, char* argv[])
     if (argc<2 || mapArgs.count("-?") || mapArgs.count("-h") || mapArgs.count("-help"))
     {
         // First part of help message is specific to this utility
-        std::string strUsage = _("Bitcoin bitcoin-tx utility version") + " " + FormatFullVersion() + "\n\n" +
+        std::string strUsage = _("Bitcoin MVF-BU bitcoin-tx utility version") + " " + FormatFullVersion() + "\n\n" +  // MVF-BU client name (MVHF-BU-DES-IDME-1)
             _("Usage:") + "\n" +
               "  bitcoin-tx [options] <hex-tx> [commands]  " + _("Update hex-encoded bitcoin transaction") + "\n" +
               "  bitcoin-tx [options] -create [commands]   " + _("Create hex-encoded bitcoin transaction") + "\n" +

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -75,7 +75,7 @@ bool AppInit(int argc, char* argv[])
     // Process help and version before taking care about datadir
     if (mapArgs.count("-?") || mapArgs.count("-h") ||  mapArgs.count("-help") || mapArgs.count("-version"))
     {
-        std::string strUsage = _("Bitcoin Unlimited Daemon") + " " + _("version") + " " + FormatFullVersion() + "\n";
+        std::string strUsage = _("Bitcoin MVF-BU Daemon") + " " + _("version") + " " + FormatFullVersion() + "\n";  // MVF-BU client name (MVHF-BU-DES-IDME-1)
 
         if (mapArgs.count("-version"))
         {
@@ -84,7 +84,7 @@ bool AppInit(int argc, char* argv[])
         else
         {
             strUsage += "\n" + _("Usage:") + "\n" +
-                  "  bitcoind [options]                     " + _("Start Bitcoin Unlimited Daemon") + "\n";
+                  "  bitcoind [options]                     " + _("Start Bitcoin MVF-BU Daemon") + "\n";  // MVF-BU client name (MVHF-BU-DES-IDME-1)
 
             strUsage += "\n" + HelpMessage(HMM_BITCOIND);
         }


### PR DESCRIPTION
- client naming for bitcoind, bitcoin-cli, bitcoin-tx
- some packaging script adaptation for new client name (OSX), not all changes markable
- added "Copyright (c) 2016 The Bitcoin Developers" in one file header, adapted year in another

Changes build, but no tests yet.
