### PR TITLE
Feature/wallet backup auto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,4 @@ share/BitcoindComparisonTool.jar
 /doc/doxygen/
 
 libbitcoinconsensus.pc
+/Debug/

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -97,6 +97,7 @@ testScripts = [
     'fundrawtransaction.py',
     'signrawtransactions.py',
     'walletbackup.py',
+    'walletbackupauto.py',
     'nodehandling.py',
     'reindex.py',
     'decodescript.py',

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python2
 # Copyright (c) 2014-2015 The Bitcoin Core developers
 # Copyright (c) 2015-2016 The Bitcoin Unlimited developers
+# Copyright (c) 2016 The Bitcoin developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -97,7 +98,7 @@ testScripts = [
     'fundrawtransaction.py',
     'signrawtransactions.py',
     'walletbackup.py',
-    'walletbackupauto.py',
+    'walletbackupauto.py', #MVHF-BU
     'nodehandling.py',
     'reindex.py',
     'decodescript.py',

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -98,7 +98,7 @@ testScripts = [
     'fundrawtransaction.py',
     'signrawtransactions.py',
     'walletbackup.py',
-    'walletbackupauto.py', #MVHF-BU
+    'walletbackupauto.py', # MVHF-BU
     'nodehandling.py',
     'reindex.py',
     'decodescript.py',

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2014-2015 The Bitcoin Core developers
 # Copyright (c) 2015-2016 The Bitcoin Unlimited developers
+# Copyright (c) 2016 The Bitcoin developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #
@@ -264,7 +265,7 @@ def start_nodes(num_nodes, dirname, extra_args=None, rpchost=None, binary=None):
 def log_filename(dirname, n_node, logname):
     return os.path.join(dirname, "node"+str(n_node), "regtest", logname)
 
-
+#MVHF-BU
 def search_file(searchfilepath, searchtext):
     searchfile = open(searchfilepath, "r")
     searchlines=list()

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -230,6 +230,10 @@ def start_node(i, dirname, extra_args=None, rpchost=None, timewait=None, binary=
     # RPC tests still depend on free transactions
     args = [ binary, "-datadir="+datadir, "-server", "-keypool=1", "-discover=0", "-rest", "-blockprioritysize=50000" ]
     if extra_args is not None: args.extend(extra_args)
+    if os.getenv("PYTHON_DEBUG", ""):
+        for i in range(len(args)):
+            print "bitcoind args: " + args[i]
+
     bitcoind_processes[i] = subprocess.Popen(args)
     devnull = open(os.devnull, "w")
     if os.getenv("PYTHON_DEBUG", ""):

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -264,6 +264,16 @@ def start_nodes(num_nodes, dirname, extra_args=None, rpchost=None, binary=None):
 def log_filename(dirname, n_node, logname):
     return os.path.join(dirname, "node"+str(n_node), "regtest", logname)
 
+
+def search_file(searchfilepath, searchtext):
+    searchfile = open(searchfilepath, "r")
+    searchlines=list()
+    for line in searchfile:
+        if searchtext in line: searchlines.append(line)
+    searchfile.close()
+    return searchlines
+
+
 def stop_node(node, i):
     node.stop()
     bitcoind_processes[i].wait()

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -265,14 +265,16 @@ def start_nodes(num_nodes, dirname, extra_args=None, rpchost=None, binary=None):
 def log_filename(dirname, n_node, logname):
     return os.path.join(dirname, "node"+str(n_node), "regtest", logname)
 
-#MVHF-BU
+# MVHF-BU begin: Function used for searching text files such as debug.log
 def search_file(searchfilepath, searchtext):
+    """Pass in the file to search and the search text and this returns a list of lines in the file which include the search text. """
     searchfile = open(searchfilepath, "r")
     searchlines=list()
     for line in searchfile:
         if searchtext in line: searchlines.append(line)
     searchfile.close()
     return searchlines
+# MVHF-BU end
 
 
 def stop_node(node, i):

--- a/qa/rpc-tests/walletbackupauto.py
+++ b/qa/rpc-tests/walletbackupauto.py
@@ -196,12 +196,6 @@ class WalletBackupTest(BitcoinTestFramework):
 
         logging.info("Re-starting nodes")
         self.start_three()
-
-        logging.info("Node0 balance:" + str(self.nodes[0].getbalance()))
-        logging.info("Node1 balance:" + str(self.nodes[1].getbalance()))
-        logging.info("Node2 balance:" + str(self.nodes[2].getbalance()))
-
-
         sync_blocks(self.nodes)
 
 
@@ -210,11 +204,10 @@ class WalletBackupTest(BitcoinTestFramework):
         logging.info("Node2 balance:" + str(self.nodes[2].getbalance()))
 
 
-
-        # balances should match the 114 block auto backup balances
-        assert_equal(self.nodes[0].getbalance(), balance0)
-        assert_equal(self.nodes[1].getbalance(), balance1)
-        assert_equal(self.nodes[2].getbalance(), balance2)
+        # balances should be greater than the 114 block auto backup balances
+        assert_greaterthan(self.nodes[0].getbalance(), balance0)
+        assert_greaterthan(self.nodes[1].getbalance(), balance1)
+        assert_greaterthan(self.nodes[2].getbalance(), balance2)
 
 
 if __name__ == '__main__':

--- a/qa/rpc-tests/walletbackupauto.py
+++ b/qa/rpc-tests/walletbackupauto.py
@@ -9,7 +9,9 @@ Exercise the auto backup wallet code.  Ported from walletbackup.sh.
 
 Test case is:
 4 nodes. 1 2 and 3 send transactions between each other,
-fourth node is a miner.
+fourth node is a miner
+5th node does nothing and tests disabled wallet
+.
 1 2 3 each mine a block to start, then
 Miner creates 100 blocks so 1 2 3 each have 50 mature
 coins to spend.
@@ -34,10 +36,11 @@ transaction fees paid mature.
 
 1/2/3 are shutdown, and their wallets erased.
 Then restored using wallet.dat.auto.114.bak backup.
-Sanity check to confirm 1/2/3/4 balances match the 114 block balances.
-
+Sanity check to confirm 1/2/3 balances match the 114 block balances.
+Sanity check to confirm 5th node does not perform the auto backup
 """
 
+import os
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 from random import randint
@@ -48,14 +51,14 @@ class WalletBackupTest(BitcoinTestFramework):
 
     def setup_chain(self):
         logging.info("Initializing test directory "+self.options.tmpdir)
-        initialize_chain_clean(self.options.tmpdir, 4)
+        initialize_chain_clean(self.options.tmpdir, 5)
 
     # This mirrors how the network was setup in the bash test
     def setup_network(self, split=False):
         # nodes 1, 2,3 are spenders, let's give them a keypool=100
-        # and configure option autobackupwalletpath option enabled for block 114
+        # and configure option autobackupwalletpath enabled for block 114
 
-        logging.info("Starting nodes...")
+        logging.info("Starting nodes")
 
         extra_args = [
             ["-keypool=100",
@@ -66,13 +69,18 @@ class WalletBackupTest(BitcoinTestFramework):
                 "-autobackupblock=114"],
             ["-keypool=100",
                 "-autobackupwalletpath="+self.options.tmpdir+"/node2",
-                "-autobackupblock=114"], []]
+                "-autobackupblock=114"],
+            [],
+            ["-disablewallet",
+                "-autobackupwalletpath="+self.options.tmpdir+"/node4",
+                "-autobackupblock=114"]]
 
-        self.nodes = start_nodes(4, self.options.tmpdir, extra_args)
+        self.nodes = start_nodes(5, self.options.tmpdir, extra_args)
         connect_nodes(self.nodes[0], 3)
         connect_nodes(self.nodes[1], 3)
         connect_nodes(self.nodes[2], 3)
         connect_nodes(self.nodes[2], 0)
+        connect_nodes(self.nodes[4], 3)
         self.is_network_split=False
         self.sync_all()
 
@@ -158,25 +166,19 @@ class WalletBackupTest(BitcoinTestFramework):
         balance1 = self.nodes[1].getbalance()
         balance2 = self.nodes[2].getbalance()
         balance3 = self.nodes[3].getbalance()
+
         total = balance0 + balance1 + balance2 + balance3
 
         logging.info("Node0 balance:" + str(balance0))
         logging.info("Node1 balance:" + str(balance1))
         logging.info("Node2 balance:" + str(balance2))
+        logging.info("Node3 balance:" + str(balance3))
+
+        logging.info("Total: " + str(total))
 
         # At this point, there are 214 blocks (103 for setup, then 10 rounds, then 101.)
         # 114 are mature, so the sum of all wallets should be 114 * 50 = 5700.
         assert_equal(total, 5700)
-
-
-        # these transactions should NOT be in the backup
-        logging.info("More transactions")
-        for i in range(5):
-            self.do_one_round()
-
-        # Generate 101 more blocks, so any fees paid mature
-        self.nodes[3].generate(101)
-        self.sync_all()
 
         ##
         # Test restoring spender wallets from backups
@@ -196,19 +198,32 @@ class WalletBackupTest(BitcoinTestFramework):
 
         logging.info("Re-starting nodes")
         self.start_three()
-        sync_blocks(self.nodes)
+        sync_blocks(self.nodes, 10)
 
-
+        total2 = total = self.nodes[0].getbalance() + self.nodes[1].getbalance() + self.nodes[2].getbalance() + self.nodes[3].getbalance()
         logging.info("Node0 balance:" + str(self.nodes[0].getbalance()))
         logging.info("Node1 balance:" + str(self.nodes[1].getbalance()))
         logging.info("Node2 balance:" + str(self.nodes[2].getbalance()))
+        logging.info("Node3.balance:" + str(self.nodes[3].getbalance()))
+
+        logging.info("Total: " + str(total2))
 
 
-        # balances should be greater than the 114 block auto backup balances
-        assert_greaterthan(self.nodes[0].getbalance(), balance0)
-        assert_greaterthan(self.nodes[1].getbalance(), balance1)
-        assert_greaterthan(self.nodes[2].getbalance(), balance2)
 
+        # Test Node4 auto backup wallet does NOT exist: tmpdir + "/node3/wallet.dat.auto.114.bak"
+        # when -disablewallet is enabled then no backup file should be created and graceful exit happens
+        # without causing a runtime error
+        node4backupexists = 0
+        if os.path.isfile(tmpdir + "/node4/wallet.dat.auto.114.bak"):
+            node4backupexists = 1
+            logging.info("Error: Auto backup performed on node4 with -disablewallet!")
+
+
+        # balances should equal the 114 block auto backup balances
+        assert_equal(self.nodes[0].getbalance(), balance0)
+        assert_equal(self.nodes[1].getbalance(), balance1)
+        assert_equal(self.nodes[2].getbalance(), balance2)
+        assert_equal(0,node4backupexists)
 
 if __name__ == '__main__':
     WalletBackupTest().main()

--- a/qa/rpc-tests/walletbackupauto.py
+++ b/qa/rpc-tests/walletbackupauto.py
@@ -8,13 +8,11 @@
 Exercise the auto backup wallet code.  Ported from walletbackup.sh.
 
 Test case is:
-4 nodes. 1 2 and 3 send transactions between each other,
-fourth node is a miner
-5th node does nothing and tests disabled wallet
+4 nodes. 1 2 and 3 send transactions between each other, fourth node is a miner
+5th node does no transactions and only tests the -disablewallet
 .
 1 2 3 each mine a block to start, then
-Miner creates 100 blocks so 1 2 3 each have 50 mature
-coins to spend.
+Miner creates 100 blocks so 1 2 3 each have 50 mature coins to spend.
 Then 5 iterations of 1/2/3 sending coins amongst
 themselves to get transactions in the wallets,
 and the miner mining one block.
@@ -37,7 +35,8 @@ transaction fees paid mature.
 1/2/3 are shutdown, and their wallets erased.
 Then restored using wallet.dat.auto.114.bak backup.
 Sanity check to confirm 1/2/3 balances match the 114 block balances.
-Sanity check to confirm 5th node does not perform the auto backup
+Sanity check to confirm 5th node does NOT perform the auto backup
+and that the debug.log contains a conflict message
 """
 
 import os
@@ -219,11 +218,15 @@ class WalletBackupTest(BitcoinTestFramework):
             logging.info("Error: Auto backup performed on node4 with -disablewallet!")
 
 
+        # Test Node4 debug.log contains a conflict message - length test should be > 0
+        debugmsg_list = search_file(tmpdir + "/node4/regtest/debug.log","-disablewallet and -autobackupwalletpath conflict")
+
         # balances should equal the 114 block auto backup balances
         assert_equal(self.nodes[0].getbalance(), balance0)
         assert_equal(self.nodes[1].getbalance(), balance1)
         assert_equal(self.nodes[2].getbalance(), balance2)
         assert_equal(0,node4backupexists)
+        assert_greater_than(len(debugmsg_list),0)
 
 if __name__ == '__main__':
     WalletBackupTest().main()

--- a/qa/rpc-tests/walletbackupauto.py
+++ b/qa/rpc-tests/walletbackupauto.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python2
+# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2015-2016 The Bitcoin Unlimited developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+# MVHF-BU
+"""
+Exercise the auto backup wallet code.  Ported from walletbackup.sh.
+
+Test case is:
+4 nodes. 1 2 and 3 send transactions between each other,
+fourth node is a miner.
+1 2 3 each mine a block to start, then
+Miner creates 100 blocks so 1 2 3 each have 50 mature
+coins to spend.
+Then 5 iterations of 1/2/3 sending coins amongst
+themselves to get transactions in the wallets,
+and the miner mining one block.
+
+Then 5 more iterations of transactions and mining a block.
+
+Miner then generates 101 more blocks, so any
+transaction fees paid mature.
+
+The node config sets wallets to automatically back up at block 114.
+
+Balances are saved for sanity check:
+  Sum(1,2,3,4 balances) == 114*50
+
+Then 5 more iterations of transactions and mining a block.
+
+Miner then generates 101 more blocks, so any
+transaction fees paid mature.
+
+1/2/3 are shutdown, and their wallets erased.
+Then restored using wallet.dat.auto.114.bak backup.
+Sanity check to confirm 1/2/3/4 balances match the 114 block balances.
+
+"""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+from random import randint
+import logging
+logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.INFO)
+
+class WalletBackupTest(BitcoinTestFramework):
+
+    def setup_chain(self):
+        logging.info("Initializing test directory "+self.options.tmpdir)
+        initialize_chain_clean(self.options.tmpdir, 4)
+
+    # This mirrors how the network was setup in the bash test
+    def setup_network(self, split=False):
+        # nodes 1, 2,3 are spenders, let's give them a keypool=100
+        # and configure option autobackupwalletpath option enabled for block 114
+
+        logging.info("Starting nodes...")
+
+        extra_args = [
+            ["-keypool=100",
+                "-autobackupwalletpath="+self.options.tmpdir+"/node0",
+                "-autobackupblock=114"],
+            ["-keypool=100",
+                "-autobackupwalletpath="+self.options.tmpdir+"/node1",
+                "-autobackupblock=114"],
+            ["-keypool=100",
+                "-autobackupwalletpath="+self.options.tmpdir+"/node2",
+                "-autobackupblock=114"], []]
+
+        self.nodes = start_nodes(4, self.options.tmpdir, extra_args)
+        connect_nodes(self.nodes[0], 3)
+        connect_nodes(self.nodes[1], 3)
+        connect_nodes(self.nodes[2], 3)
+        connect_nodes(self.nodes[2], 0)
+        self.is_network_split=False
+        self.sync_all()
+
+    def one_send(self, from_node, to_address):
+        if (randint(1,2) == 1):
+            amount = Decimal(randint(1,10)) / Decimal(10)
+            self.nodes[from_node].sendtoaddress(to_address, amount)
+
+    def do_one_round(self):
+        a0 = self.nodes[0].getnewaddress()
+        a1 = self.nodes[1].getnewaddress()
+        a2 = self.nodes[2].getnewaddress()
+
+        self.one_send(0, a1)
+        self.one_send(0, a2)
+        self.one_send(1, a0)
+        self.one_send(1, a2)
+        self.one_send(2, a0)
+        self.one_send(2, a1)
+
+        # Have the miner (node3) mine a block.
+        # Must sync mempools before mining.
+        sync_mempools(self.nodes)
+        self.nodes[3].generate(1)
+
+    # As above, this mirrors the original bash test.
+    def start_three(self):
+
+        self.nodes[0] = start_node(0, self.options.tmpdir)
+        self.nodes[1] = start_node(1, self.options.tmpdir)
+        self.nodes[2] = start_node(2, self.options.tmpdir)
+
+        connect_nodes(self.nodes[0], 3)
+        connect_nodes(self.nodes[1], 3)
+        connect_nodes(self.nodes[2], 3)
+        connect_nodes(self.nodes[2], 0)
+
+    def stop_three(self):
+        stop_node(self.nodes[0], 0)
+        stop_node(self.nodes[1], 1)
+        stop_node(self.nodes[2], 2)
+
+    def erase_three(self):
+        os.remove(self.options.tmpdir + "/node0/regtest/wallet.dat")
+        os.remove(self.options.tmpdir + "/node1/regtest/wallet.dat")
+        os.remove(self.options.tmpdir + "/node2/regtest/wallet.dat")
+
+    def run_test(self):
+        logging.info("Generating initial blockchain")
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+        self.nodes[1].generate(1)
+        sync_blocks(self.nodes)
+        self.nodes[2].generate(1)
+        sync_blocks(self.nodes)
+        self.nodes[3].generate(100)
+        sync_blocks(self.nodes)
+
+        assert_equal(self.nodes[0].getbalance(), 50)
+        assert_equal(self.nodes[1].getbalance(), 50)
+        assert_equal(self.nodes[2].getbalance(), 50)
+        assert_equal(self.nodes[3].getbalance(), 0)
+
+        tmpdir = self.options.tmpdir
+
+        logging.info("Creating transactions")
+        # Five rounds of sending each other transactions.
+        for i in range(5):
+            self.do_one_round()
+
+
+        logging.info("More transactions")
+        for i in range(5):
+            self.do_one_round()
+
+        # Generate 101 more blocks, so any fees paid mature
+        self.nodes[3].generate(101)
+        self.sync_all()
+
+        logging.info("Reached block 114. Auto backup triggered.")
+
+        balance0 = self.nodes[0].getbalance()
+        balance1 = self.nodes[1].getbalance()
+        balance2 = self.nodes[2].getbalance()
+        balance3 = self.nodes[3].getbalance()
+        total = balance0 + balance1 + balance2 + balance3
+
+        logging.info("Node0 balance:" + str(balance0))
+        logging.info("Node1 balance:" + str(balance1))
+        logging.info("Node2 balance:" + str(balance2))
+
+        # At this point, there are 214 blocks (103 for setup, then 10 rounds, then 101.)
+        # 114 are mature, so the sum of all wallets should be 114 * 50 = 5700.
+        assert_equal(total, 5700)
+
+
+        # these transactions should NOT be in the backup
+        logging.info("More transactions")
+        for i in range(5):
+            self.do_one_round()
+
+        # Generate 101 more blocks, so any fees paid mature
+        self.nodes[3].generate(101)
+        self.sync_all()
+
+        ##
+        # Test restoring spender wallets from backups
+        ##
+        logging.info("Restoring using wallet.dat.auto.114.bak")
+        self.stop_three()
+        self.erase_three()
+
+        # Start node2 with no chain
+        shutil.rmtree(self.options.tmpdir + "/node2/regtest/blocks")
+        shutil.rmtree(self.options.tmpdir + "/node2/regtest/chainstate")
+
+        # Restore wallets from backup
+        shutil.copyfile(tmpdir + "/node0/wallet.dat.auto.114.bak", tmpdir + "/node0/regtest/wallet.dat")
+        shutil.copyfile(tmpdir + "/node1/wallet.dat.auto.114.bak", tmpdir + "/node1/regtest/wallet.dat")
+        shutil.copyfile(tmpdir + "/node2/wallet.dat.auto.114.bak", tmpdir + "/node2/regtest/wallet.dat")
+
+        logging.info("Re-starting nodes")
+        self.start_three()
+
+        logging.info("Node0 balance:" + str(self.nodes[0].getbalance()))
+        logging.info("Node1 balance:" + str(self.nodes[1].getbalance()))
+        logging.info("Node2 balance:" + str(self.nodes[2].getbalance()))
+
+
+        sync_blocks(self.nodes)
+
+
+        logging.info("Node0 balance:" + str(self.nodes[0].getbalance()))
+        logging.info("Node1 balance:" + str(self.nodes[1].getbalance()))
+        logging.info("Node2 balance:" + str(self.nodes[2].getbalance()))
+
+
+
+        # balances should match the 114 block auto backup balances
+        assert_equal(self.nodes[0].getbalance(), balance0)
+        assert_equal(self.nodes[1].getbalance(), balance1)
+        assert_equal(self.nodes[2].getbalance(), balance2)
+
+
+if __name__ == '__main__':
+    WalletBackupTest().main()

--- a/qa/rpc-tests/walletbackupauto.py
+++ b/qa/rpc-tests/walletbackupauto.py
@@ -9,8 +9,8 @@
 Exercise the auto backup wallet code.  Ported from walletbackup.sh.
 
 Test case is:
-4 nodes. 1 2 and 3 send transactions between each other, fourth node is a miner
-5th node does no transactions and only tests the -disablewallet
+5 nodes. 1 2 and 3 send transactions between each other, fourth node is a miner.
+The 5th node does no transactions and only tests for the -disablewallet conflict.
 .
 1 2 3 each mine a block to start, then
 Miner creates 100 blocks so 1 2 3 each have 50 mature coins to spend.

--- a/qa/rpc-tests/walletbackupauto.py
+++ b/qa/rpc-tests/walletbackupauto.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python2
 # Copyright (c) 2014-2015 The Bitcoin Core developers
 # Copyright (c) 2015-2016 The Bitcoin Unlimited developers
+# Copyright (c) 2016 The Bitcoin developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 # MVHF-BU

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -402,6 +402,9 @@ std::string HelpMessage(HelpMessageMode mode)
 
 #ifdef ENABLE_WALLET
     strUsage += HelpMessageGroup(_("Wallet options:"));
+
+    strUsage += HelpMessageOpt("-autobackupwalletpath=<path>", _("Default: Enabled. Automatically backup the wallet to the autobackupwalletfile path after the block specified becomes the best block (-autobackupblock)."));
+    strUsage += HelpMessageOpt("-autobackupblock=<n>", _("Default: MVHF-BU FORKBLOCK-1. Specify the block number that triggers the automatic wallet backup."));
     strUsage += HelpMessageOpt("-disablewallet", _("Do not load the wallet and disable wallet RPC calls"));
     strUsage += HelpMessageOpt("-keypool=<n>", strprintf(_("Set key pool size to <n> (default: %u)"), DEFAULT_KEYPOOL_SIZE));
     strUsage += HelpMessageOpt("-fallbackfee=<amt>", strprintf(_("A fee rate (in %s/kB) that will be used when fee estimation has insufficient data (default: %s)"),
@@ -784,6 +787,11 @@ void InitParameterInteraction()
         if (SoftSetBoolArg("-walletbroadcast", false))
             LogPrintf("%s: parameter interaction: -blocksonly=1 -> setting -walletbroadcast=0\n", __func__);
 #endif
+    }
+
+    if (GetArg("-autobackupwalletpath","") != "" && (GetBoolArg("-disablewallet", false)) ) {
+    	LogPrintf("%s: parameter interaction: -disablewallet and -autobackupwalletpath conflict so automatic backup disabled.=0\n");
+
     }
 
     // Forcing relay from whitelisted hosts implies we will accept relays from them in the first place.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2786,8 +2786,6 @@ void static UpdateTip(CBlockIndex *pindexNew) {
       Checkpoints::GuessVerificationProgress(chainParams.Checkpoints(), chainActive.Tip()), pcoinsTip->DynamicMemoryUsage() * (1.0 / (1<<20)), pcoinsTip->GetCacheSize());
 
     cvBlockChange.notify_all();
-    
-    
 
     // MVHF-BU
     const int MVHF_FORK_BLOCK = 50000;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2801,24 +2801,21 @@ void static UpdateTip(CBlockIndex *pindexNew) {
 		//LogPrintf("DEBUG: autobackupwalletpath=%s\n",strWalletBackupFile);
 		//LogPrintf("DEBUG: autobackupblock=%d\n",BackupBlock);
 
-		if(strWalletBackupFile != "") {
+		if (GetBoolArg("-disablewallet", false)) {
+			LogPrintf("-disablewallet and -autobackupwalletpath conflict so automatic backup disabled.");
+			fAutoBackupDone = true;
+		}
+		else
+			// Auto Backup defined so check block height
+			if (chainActive.Height() >= BackupBlock )
+			{
+				if (GetMainSignals().BackupWalletAuto(strWalletBackupFile, BackupBlock))
+					fAutoBackupDone = true;
+				else
+					throw std::runtime_error("CWallet::BackupWalletAuto() : Auto wallet backup failed!");
 
-			if (GetBoolArg("-disablewallet", false)) {
-				LogPrintf("-disablewallet and -autobackupwalletpath conflict so automatic backup disabled.");
-				fAutoBackupDone = true;
 			}
-			else
-				// Auto Backup defined so check block height
-				if (chainActive.Height() >= BackupBlock )
-				{
-					if (GetMainSignals().BackupWalletAuto(strWalletBackupFile, BackupBlock))
-						fAutoBackupDone = true;
-					else
-						throw std::runtime_error("CWallet::BackupWalletAuto() : Auto wallet backup failed!");
 
-				}
-
-		} // if(strWalletBackupFile != "")
     } // if (!fAutoBackupDone)
 
     // Check the version of the last 100 blocks to see if we need to upgrade:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2784,6 +2784,29 @@ void static UpdateTip(CBlockIndex *pindexNew) {
       Checkpoints::GuessVerificationProgress(chainParams.Checkpoints(), chainActive.Tip()), pcoinsTip->DynamicMemoryUsage() * (1.0 / (1<<20)), pcoinsTip->GetCacheSize());
 
     cvBlockChange.notify_all();
+    
+    
+
+    // MVHF-BU
+    const int MVHF_FORK_BLOCK = 50000;
+
+    //// 	Auto Backup At Block 		////
+    // Test autobackupwalletpath argument
+    std::string strWalletBackupFile = GetArg("-autobackupwalletpath", "");
+    int BackupBlock = GetArg("-autobackupblock", MVHF_FORK_BLOCK - 1);
+
+    //LogPrintf("DEBUG: autobackupwalletpath=%s\n",strWalletBackupFile);
+    //LogPrintf("DEBUG: autobackupblock=%d\n",BackupBlock);
+
+    if(strWalletBackupFile != "") { 
+		// Auto Backup defined so check block height
+		if (chainActive.Height() >= BackupBlock )
+		{
+			if (!GetMainSignals().BackupWalletAuto(strWalletBackupFile, BackupBlock))
+				throw std::runtime_error("CWallet::BackupWalletAuto() : Auto wallet backup failed!");
+		}
+		
+    } // if(strWalletBackupFile != "") 
 
     // Check the version of the last 100 blocks to see if we need to upgrade:
     static bool fWarned = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2009-2015 The Bitcoin Core developers
 // Copyright (c) 2015-2016 The Bitcoin Unlimited developers
 // Copyright (c) 2016 Bitcoin Unlimited developers
+// Copyright (c) 2016 The Bitcoin developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -82,7 +83,7 @@ size_t nCoinCacheUsage = 5000 * 300;
 uint64_t nPruneTarget = 0;
 bool fAlerts = DEFAULT_ALERTS;
 bool fEnableReplacement = DEFAULT_ENABLE_REPLACEMENT;
-bool fAutoBackupDone = false;
+bool fAutoBackupDone = false; // MVHF-BU
 
 /** Fees smaller than this (in satoshi) are considered zero fee (for relaying, mining and transaction creation) */
 CFeeRate minRelayTxFee = CFeeRate(DEFAULT_MIN_RELAY_TX_FEE);

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -53,12 +53,11 @@ void UnregisterAllValidationInterfaces() {
     g_signals.Broadcast.disconnect_all_slots();
     g_signals.Inventory.disconnect_all_slots();
     g_signals.SetBestChain.disconnect_all_slots();
-    g_signals.BackupWalletAuto.disconnect_all_slots();  //MVHF-BU
+    g_signals.BackupWalletAuto.disconnect_all_slots();  // MVHF-BU
 	g_signals.UpdatedTransaction.disconnect_all_slots();
     g_signals.SyncTransaction.disconnect_all_slots();
     g_signals.UpdatedBlockTip.disconnect_all_slots();
 }
-
 
 void SyncWithWallets(const CTransaction &tx, const CBlock *pblock) {
     g_signals.SyncTransaction(tx, pblock);

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -18,6 +18,7 @@ void RegisterValidationInterface(CValidationInterface* pwalletIn) {
     g_signals.SyncTransaction.connect(boost::bind(&CValidationInterface::SyncTransaction, pwalletIn, _1, _2));
     g_signals.UpdatedTransaction.connect(boost::bind(&CValidationInterface::UpdatedTransaction, pwalletIn, _1));
     g_signals.SetBestChain.connect(boost::bind(&CValidationInterface::SetBestChain, pwalletIn, _1));
+    g_signals.BackupWalletAuto.connect(boost::bind(&CValidationInterface::BackupWalletAuto, pwalletIn, _1, _2));
     g_signals.Inventory.connect(boost::bind(&CValidationInterface::Inventory, pwalletIn, _1));
     g_signals.Broadcast.connect(boost::bind(&CValidationInterface::ResendWalletTransactions, pwalletIn, _1));
     g_signals.BlockChecked.connect(boost::bind(&CValidationInterface::BlockChecked, pwalletIn, _1, _2));
@@ -32,6 +33,7 @@ void UnregisterValidationInterface(CValidationInterface* pwalletIn) {
     g_signals.Broadcast.disconnect(boost::bind(&CValidationInterface::ResendWalletTransactions, pwalletIn, _1));
     g_signals.Inventory.disconnect(boost::bind(&CValidationInterface::Inventory, pwalletIn, _1));
     g_signals.SetBestChain.disconnect(boost::bind(&CValidationInterface::SetBestChain, pwalletIn, _1));
+    g_signals.BackupWalletAuto.disconnect(boost::bind(&CValidationInterface::BackupWalletAuto, pwalletIn, _1, _2));
     g_signals.UpdatedTransaction.disconnect(boost::bind(&CValidationInterface::UpdatedTransaction, pwalletIn, _1));
     g_signals.SyncTransaction.disconnect(boost::bind(&CValidationInterface::SyncTransaction, pwalletIn, _1, _2));
     g_signals.UpdatedBlockTip.disconnect(boost::bind(&CValidationInterface::UpdatedBlockTip, pwalletIn, _1));
@@ -44,10 +46,12 @@ void UnregisterAllValidationInterfaces() {
     g_signals.Broadcast.disconnect_all_slots();
     g_signals.Inventory.disconnect_all_slots();
     g_signals.SetBestChain.disconnect_all_slots();
-    g_signals.UpdatedTransaction.disconnect_all_slots();
+	g_signals.BackupWalletAuto.disconnect_all_slots();
+	g_signals.UpdatedTransaction.disconnect_all_slots();
     g_signals.SyncTransaction.disconnect_all_slots();
     g_signals.UpdatedBlockTip.disconnect_all_slots();
 }
+
 
 void SyncWithWallets(const CTransaction &tx, const CBlock *pblock) {
     g_signals.SyncTransaction(tx, pblock);

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin Core developers
 // Copyright (c) 2015-2016 The Bitcoin Unlimited developers
+// Copyright (c) 2016 The Bitcoin developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -18,7 +19,10 @@ void RegisterValidationInterface(CValidationInterface* pwalletIn) {
     g_signals.SyncTransaction.connect(boost::bind(&CValidationInterface::SyncTransaction, pwalletIn, _1, _2));
     g_signals.UpdatedTransaction.connect(boost::bind(&CValidationInterface::UpdatedTransaction, pwalletIn, _1));
     g_signals.SetBestChain.connect(boost::bind(&CValidationInterface::SetBestChain, pwalletIn, _1));
+
+    // MVHF-BU
     g_signals.BackupWalletAuto.connect(boost::bind(&CValidationInterface::BackupWalletAuto, pwalletIn, _1, _2));
+
     g_signals.Inventory.connect(boost::bind(&CValidationInterface::Inventory, pwalletIn, _1));
     g_signals.Broadcast.connect(boost::bind(&CValidationInterface::ResendWalletTransactions, pwalletIn, _1));
     g_signals.BlockChecked.connect(boost::bind(&CValidationInterface::BlockChecked, pwalletIn, _1, _2));
@@ -33,7 +37,10 @@ void UnregisterValidationInterface(CValidationInterface* pwalletIn) {
     g_signals.Broadcast.disconnect(boost::bind(&CValidationInterface::ResendWalletTransactions, pwalletIn, _1));
     g_signals.Inventory.disconnect(boost::bind(&CValidationInterface::Inventory, pwalletIn, _1));
     g_signals.SetBestChain.disconnect(boost::bind(&CValidationInterface::SetBestChain, pwalletIn, _1));
+
+    // MVHF-BU
     g_signals.BackupWalletAuto.disconnect(boost::bind(&CValidationInterface::BackupWalletAuto, pwalletIn, _1, _2));
+
     g_signals.UpdatedTransaction.disconnect(boost::bind(&CValidationInterface::UpdatedTransaction, pwalletIn, _1));
     g_signals.SyncTransaction.disconnect(boost::bind(&CValidationInterface::SyncTransaction, pwalletIn, _1, _2));
     g_signals.UpdatedBlockTip.disconnect(boost::bind(&CValidationInterface::UpdatedBlockTip, pwalletIn, _1));
@@ -46,7 +53,7 @@ void UnregisterAllValidationInterfaces() {
     g_signals.Broadcast.disconnect_all_slots();
     g_signals.Inventory.disconnect_all_slots();
     g_signals.SetBestChain.disconnect_all_slots();
-	g_signals.BackupWalletAuto.disconnect_all_slots();
+    g_signals.BackupWalletAuto.disconnect_all_slots();  //MVHF-BU
 	g_signals.UpdatedTransaction.disconnect_all_slots();
     g_signals.SyncTransaction.disconnect_all_slots();
     g_signals.UpdatedBlockTip.disconnect_all_slots();

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -37,7 +37,7 @@ protected:
     virtual void SyncTransaction(const CTransaction &tx, const CBlock *pblock) {}
     virtual void SetBestChain(const CBlockLocator &locator) {}
 
-    //MVHF-BU
+    // MVHF-BU
     virtual bool BackupWalletAuto(const std::string& strDest, int BackupBlock) {return true;}
 
     virtual void UpdatedTransaction(const uint256 &hash) {}

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -35,6 +35,7 @@ protected:
     virtual void UpdatedBlockTip(const CBlockIndex *pindex) {}
     virtual void SyncTransaction(const CTransaction &tx, const CBlock *pblock) {}
     virtual void SetBestChain(const CBlockLocator &locator) {}
+    virtual bool BackupWalletAuto(const std::string& strDest, int BackupBlock) {return true;}
     virtual void UpdatedTransaction(const uint256 &hash) {}
     virtual void Inventory(const uint256 &hash) {}
     virtual void ResendWalletTransactions(int64_t nBestBlockTime) {}
@@ -55,7 +56,9 @@ struct CMainSignals {
     boost::signals2::signal<void (const uint256 &)> UpdatedTransaction;
     /** Notifies listeners of a new active block chain. */
     boost::signals2::signal<void (const CBlockLocator &)> SetBestChain;
-    /** Notifies listeners about an inventory item being seen on the network. */
+    /** Notifies listeners of a new active block chain. */
+    boost::signals2::signal<bool (const std::string& strDest, int BackupBlock)> BackupWalletAuto;
+    /** Notifies listeners of a new active block chain. */
     boost::signals2::signal<void (const uint256 &)> Inventory;
     /** Tells listeners to broadcast their data. */
     boost::signals2::signal<void (int64_t nBestBlockTime)> Broadcast;

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -1,6 +1,7 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2015 The Bitcoin Core developers
 // Copyright (c) 2015-2016 The Bitcoin Unlimited developers
+// Copyright (c) 2016 The Bitcoin developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -35,7 +36,10 @@ protected:
     virtual void UpdatedBlockTip(const CBlockIndex *pindex) {}
     virtual void SyncTransaction(const CTransaction &tx, const CBlock *pblock) {}
     virtual void SetBestChain(const CBlockLocator &locator) {}
+
+    //MVHF-BU
     virtual bool BackupWalletAuto(const std::string& strDest, int BackupBlock) {return true;}
+
     virtual void UpdatedTransaction(const uint256 &hash) {}
     virtual void Inventory(const uint256 &hash) {}
     virtual void ResendWalletTransactions(int64_t nBestBlockTime) {}
@@ -56,8 +60,10 @@ struct CMainSignals {
     boost::signals2::signal<void (const uint256 &)> UpdatedTransaction;
     /** Notifies listeners of a new active block chain. */
     boost::signals2::signal<void (const CBlockLocator &)> SetBestChain;
-    /** Notifies listeners of a new active block chain. */
+
+    /** MVHF-BU Notifies listeners of a new active block chain. */
     boost::signals2::signal<bool (const std::string& strDest, int BackupBlock)> BackupWalletAuto;
+
     /** Notifies listeners of a new active block chain. */
     boost::signals2::signal<void (const uint256 &)> Inventory;
     /** Tells listeners to broadcast their data. */

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2015 The Bitcoin Core developers
 // Copyright (c) 2015-2016 The Bitcoin Unlimited developers
+// Copyright (c) 2016 The Bitcoin developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -291,6 +291,9 @@ bool CWallet::ChangeWalletPassphrase(const SecureString& strOldWalletPassphrase,
     return false;
 }
 
+
+
+
 void CWallet::SetBestChain(const CBlockLocator& loc)
 {
     CWalletDB walletdb(strWalletFile);
@@ -1039,6 +1042,38 @@ CAmount CWallet::GetChange(const CTransaction& tx) const
     }
     return nChange;
 }
+
+
+
+// MVHF-BU Auto wallet backup
+bool CWallet::BackupWalletAuto(const std::string& strDest, int BackupBlock)
+{
+
+    boost::filesystem::path pathBackupWallet = strDest;
+
+    // Test for directory only, if so add default filename
+	if (boost::filesystem::is_directory(strDest))
+		pathBackupWallet = pathBackupWallet / strprintf("%s%s",strWalletFile,".auto.#.bak");
+
+	std::string strBackupFile = pathBackupWallet.string();
+
+	// replace # with BackupBlock number
+	boost::replace_all(strBackupFile,"#", boost::to_string_stub(BackupBlock));
+
+	//skip if already done
+	if (!boost::filesystem::exists(strBackupFile))
+	{
+		// Call common backup wallet function
+		if (BackupWallet(*this, strBackupFile))
+			LogPrintf("Wallet automatically backed up to: %s\n",strBackupFile);
+		else
+			return false;
+	}
+
+	return true;
+}
+
+
 
 int64_t CWalletTx::GetTxTime() const
 {
@@ -3058,3 +3093,5 @@ bool CMerkleTx::AcceptToMemoryPool(bool fLimitFree, bool fRejectAbsurdFee)
     CValidationState state;
     return ::AcceptToMemoryPool(mempool, state, *this, fLimitFree, NULL, false, fRejectAbsurdFee);
 }
+
+

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1,6 +1,7 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2015 The Bitcoin Core developers
 // Copyright (c) 2015-2016 The Bitcoin Unlimited developers
+// Copyright (c) 2016 The Bitcoin developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -28,6 +28,7 @@
 
 #include <boost/shared_ptr.hpp>
 
+
 /**
  * Settings
  */
@@ -405,6 +406,8 @@ public:
     bool RelayWalletTransaction();
 
     std::set<uint256> GetConflicts() const;
+
+
 };
 
 
@@ -571,6 +574,9 @@ public:
 
     const CWalletTx* GetWalletTx(const uint256& hash) const;
 
+    // MVHF-BU
+    bool BackupWalletAuto(const std::string& strDest, int BackupBlock);
+
     //! check whether we are allowed to upgrade (or already support) to the named feature
     bool CanSupportFeature(enum WalletFeature wf) { AssertLockHeld(cs_wallet); return nWalletMaxVersion >= wf; }
 
@@ -713,6 +719,7 @@ public:
     CAmount GetDebit(const CTransaction& tx, const isminefilter& filter) const;
     CAmount GetCredit(const CTransaction& tx, const isminefilter& filter) const;
     CAmount GetChange(const CTransaction& tx) const;
+
     void SetBestChain(const CBlockLocator& loc);
 
     DBErrors LoadWallet(bool& fFirstRunRet);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -408,7 +408,6 @@ public:
 
     std::set<uint256> GetConflicts() const;
 
-
 };
 
 


### PR DESCRIPTION
This is the auto wallet backup feature. There are 2 command line parameters to enable the feature:
-autobackupwalletpath=/mybackupfolder
-autobackupblock=1234

The autobackupwalletpath may be a directory or file name. A hash character (#) in the string will be replaced with the block number specified. If the path is a directory then the default filename will be used which is the existing wallet file name with suffix ".auto.#.bak".

The autobackupblock number is optional and will default to the MVHF fork block. At the moment this is hard coded and so this section will need to be updated when the hard fork is better defined. Beyond the hard fork users could use this parameter to perform an auto backup at any future block number.  

If used with -disablewallet the feature is non-functional and outputs a conflict message to debug.log.

There is a regtest that can be run for this feature : qa/pull-tester/rpc-tests.py walletbackupauto
