### PR TITLE
add -forkid option (MVHF-BU-DES-CSIG-1 / MVHF-BU-DES-CSIG-1)

### DIFF
--- a/src/mvf-bu.cpp
+++ b/src/mvf-bu.cpp
@@ -74,7 +74,7 @@ void ForkSetup(const CChainParams& chainparams)
     }
 
     FinalForkId = GetArg("-forkid", HARDFORK_SIGHASH_ID);
-    // check forkid for validity
+    // check fork id for validity (MVHF-BU-DES-CSIG-2)
     if (FinalForkId == 0) {
         LogPrintf("MVF: Warning: fork id = 0 will result in vulnerability to replay attacks\n");
     }

--- a/src/mvf-bu.cpp
+++ b/src/mvf-bu.cpp
@@ -13,6 +13,9 @@ using namespace std;
 // actual fork height, taking into account user configuration parameters (MVHF-BU-DES-TRIG-4)
 int FinalActivateForkHeight = 0;
 
+// actual fork id, taking into account user configuration parameters (MVHF-BU-DES-CSIG-1)
+int FinalForkId = 0;
+
 // track whether HF is active (MVHF-BU-DES-TRIG-5)
 bool isMVFHardForkActive = false;
 
@@ -32,6 +35,9 @@ std::string ForkCmdLineHelp()
 
     // fork height parameter (MVHF-BU-DES-TRIG-1)
     strUsage += HelpMessageOpt("-forkheight=<n>", strprintf(_("Block height at which to fork on active network (integer). Defaults (also minimums): mainnet:%u,testnet=%u,nolnet=%u,regtest=%u"), (unsigned)HARDFORK_HEIGHT_MAINNET, (unsigned)HARDFORK_HEIGHT_TESTNET, (unsigned)HARDFORK_HEIGHT_NOLNET, (unsigned)HARDFORK_HEIGHT_REGTEST));
+
+    // fork id (MVHF-BU-DES-CSIG-1)
+    strUsage += HelpMessageOpt("-forkid=<n>", strprintf(_("Fork id to use for signature change. Value must be between 0 and %d. Default is 0x%06x (%u)"), (unsigned)MAX_HARDFORK_SIGHASH_ID, (unsigned)HARDFORK_SIGHASH_ID, (unsigned)HARDFORK_SIGHASH_ID));
 
     return strUsage;
 }
@@ -65,13 +71,25 @@ void ForkSetup(const CChainParams& chainparams)
     {
         LogPrintf("MVF: Error: specified fork height (%d) is less than minimum for '%s' network (%d)\n", FinalActivateForkHeight, activeNetworkID, minForkHeightForNetwork);
         StartShutdown();
-        FinalActivateForkHeight = minForkHeightForNetwork;
+    }
+
+    FinalForkId = GetArg("-forkid", HARDFORK_SIGHASH_ID);
+    // check forkid for validity
+    if (FinalForkId == 0) {
+        LogPrintf("MVF: Warning: fork id = 0 will result in vulnerability to replay attacks\n");
+    }
+    else {
+        if (FinalForkId < 0 || FinalForkId > MAX_HARDFORK_SIGHASH_ID) {
+            LogPrintf("MVF: Error: specified fork id (%d) is not in range 0..%u\n", FinalForkId, (unsigned)MAX_HARDFORK_SIGHASH_ID);
+            StartShutdown();
+        }
     }
 
     // we should always set the activation flag to false during setup
     isMVFHardForkActive = false;
 
-    LogPrintf("%s: MVF: ForkSetup() active fork height = %d\n", __func__, FinalActivateForkHeight);
+    LogPrintf("%s: MVF: active fork height = %d\n", __func__, FinalActivateForkHeight);
+    LogPrintf("%s: MVF: active fork id = 0x%06x (%d)\n", __func__, FinalForkId, FinalForkId);
 }
 
 

--- a/src/mvf-bu.h
+++ b/src/mvf-bu.h
@@ -33,6 +33,7 @@ HARDFORK_PORT_REGTEST = 19555,       // default post-fork port on local regressi
 
 // MVHF-BU-DES-CSIG-1 - signature change parameter defaults
 HARDFORK_SIGHASH_ID = 0x777000,      // 3 byte fork id that is left-shifted by 8 bits and then ORed with the SIGHASHes
+MAX_HARDFORK_SIGHASH_ID = 0xFFFFFF,  // fork id may not exceed maximum representable in 3 bytes
 };
 
 // MVHF-BU-DES-NSEP-1 - network separation parameter defaults

--- a/src/mvf-bu.h
+++ b/src/mvf-bu.h
@@ -42,7 +42,7 @@ static const CMessageHeader::MessageStartChars pchMessageStart_HardForkMainnet  
 // MVHF-BU-DES-DIAD-1 - difficulty adjustment parameter defaults
 // MVF-BU TODO: calibrate the values for public testnets according to estimated initial present hashpower
 // values to which powLimit is reset at fork time on various networks:
-static const uint256 HARDFORK_POWLIMIT_MAINNET = uint256S("00007fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),  // mainnet
+static const uint256 HARDFORK_POWRESET_MAINNET = uint256S("00007fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),  // mainnet
                      HARDFORK_POWRESET_TESTNET = uint256S("007fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),  // testnet
                      HARDFORK_POWRESET_NOLNET  = uint256S("3fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),  // nolnet
                      HARDFORK_POWRESET_REGTEST = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");  // regtestnet


### PR DESCRIPTION
add -forkid option (MVHF-BU-DES-CSIG-1 / MVHF-BU-DES-CSIG-1)
and some minor additional stuff:
- fix naming for HARDFORK_POWRESET_MAINNET
- log active fork height at setup
