### PR TITLE
enable SegWit trigger, add initial TRIG regression test (MVHF-BU-DES-TRIG-6)

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -78,6 +78,7 @@ if EXEEXT == ".exe" and "-win" not in opts:
 testScripts = [
     'bip68-112-113-p2p.py',
     'wallet.py',
+    'mvf-bu-trig.py',
     'excessive.py',
     'listtransactions.py',
     'receivedby.py',

--- a/qa/rpc-tests/mvf-bu-trig.py
+++ b/qa/rpc-tests/mvf-bu-trig.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python2
+# Copyright (c) 2016 The Bitcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#
+# Test MVF fork triggering functionality (TRIG)
+#
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+TEST_FORKHEIGHT = 100
+
+
+class MVF_TRIG_Test(BitcoinTestFramework):
+
+    def setup_chain(self):
+        print("Initializing test directory " + self.options.tmpdir)
+        initialize_chain_clean(self.options.tmpdir, 1)
+
+    def setup_network(self):
+        self.nodes = []
+        self.is_network_split = False
+        self.nodes.append(start_node(0, self.options.tmpdir,
+                            ["-forkheight=%s" % TEST_FORKHEIGHT, ]))
+
+    def is_fork_triggered(self, node=0):
+        """ check in log file if fork has triggered and return true/false """
+        # MVF-BU TODO: extend to check using RPC info about forks
+        hf_active = search_file(self.options.tmpdir + "/node%s/regtest/debug.log" % node, "isMVFHardForkActive=1")
+        fork_actions_performed = search_file(self.options.tmpdir + "/node%s/regtest/debug.log" % node, "MVF: performing fork activation actions")
+        return (len(hf_active) > 0 and len(fork_actions_performed) == 1)
+
+    def run_test(self):
+        print "Generating %s pre-fork blocks" % (TEST_FORKHEIGHT-1)
+        self.nodes[0].generate(TEST_FORKHEIGHT-1)
+
+        # check that fork has not triggered before the height
+        assert_equal(False, self.is_fork_triggered())
+        print "Fork did not trigger prematurely"
+
+        # check that fork triggers at designated height
+        self.nodes[0].generate(TEST_FORKHEIGHT-1)
+        assert_equal(True, self.is_fork_triggered())
+        print "Fork triggered successfully"
+
+if __name__ == '__main__':
+    MVF_TRIG_Test().main()

--- a/qa/rpc-tests/mvf-bu-trig.py
+++ b/qa/rpc-tests/mvf-bu-trig.py
@@ -6,44 +6,86 @@
 #
 # Test MVF fork triggering functionality (TRIG)
 #
+# on node 0, test pure block height trigger at height 100
+# on node 1, test pure block height trigger at height 200
+# on node 2, test SegWit trigger at height 431 (432 blocks = 3 periods of 144 blocks)
+# on node 3, test block height trigger pre-empts SegWit trigger at 300
+#
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
-
-TEST_FORKHEIGHT = 100
 
 
 class MVF_TRIG_Test(BitcoinTestFramework):
 
     def setup_chain(self):
         print("Initializing test directory " + self.options.tmpdir)
-        initialize_chain_clean(self.options.tmpdir, 1)
+        initialize_chain_clean(self.options.tmpdir, 4)
 
     def setup_network(self):
         self.nodes = []
         self.is_network_split = False
         self.nodes.append(start_node(0, self.options.tmpdir,
-                            ["-forkheight=%s" % TEST_FORKHEIGHT, ]))
+                            ["-forkheight=100", ]))
+        self.nodes.append(start_node(1, self.options.tmpdir,
+                            ["-forkheight=200", ]))
+        self.nodes.append(start_node(2, self.options.tmpdir,
+                            ["-forkheight=999999",
+                             "-blockversion=%s" % 0x20000002])) # signal SegWit
+        self.nodes.append(start_node(3, self.options.tmpdir,
+                            ["-forkheight=300",
+                             "-blockversion=%s" % 0x20000002])) # signal SegWit, but forkheight should pre-empt
 
-    def is_fork_triggered(self, node=0):
+    def is_fork_triggered_on_node(self, node=0):
         """ check in log file if fork has triggered and return true/false """
         # MVF-BU TODO: extend to check using RPC info about forks
-        hf_active = search_file(self.options.tmpdir + "/node%s/regtest/debug.log" % node, "isMVFHardForkActive=1")
-        fork_actions_performed = search_file(self.options.tmpdir + "/node%s/regtest/debug.log" % node, "MVF: performing fork activation actions")
+        nodelog = self.options.tmpdir + "/node%s/regtest/debug.log" % node
+        hf_active = search_file(nodelog, "isMVFHardForkActive=1")
+        fork_actions_performed = search_file(nodelog, "MVF: performing fork activation actions")
         return (len(hf_active) > 0 and len(fork_actions_performed) == 1)
 
     def run_test(self):
-        print "Generating %s pre-fork blocks" % (TEST_FORKHEIGHT-1)
-        self.nodes[0].generate(TEST_FORKHEIGHT-1)
-
-        # check that fork has not triggered before the height
-        assert_equal(False, self.is_fork_triggered())
+        # check that fork does not triggered before the height
+        print "Generating 99 pre-fork blocks"
+        for n in xrange(len(self.nodes)):
+            self.nodes[n].generate(99)
+            assert_equal(False, self.is_fork_triggered_on_node(n))
         print "Fork did not trigger prematurely"
 
-        # check that fork triggers at designated height
-        self.nodes[0].generate(TEST_FORKHEIGHT-1)
-        assert_equal(True, self.is_fork_triggered())
-        print "Fork triggered successfully"
+        # check that fork triggers for nodes 0 and 1 at designated height
+        # move all nodes to height 100
+        for n in xrange(len(self.nodes)):
+            self.nodes[n].generate(1)
+        assert_equal(True,   self.is_fork_triggered_on_node(0))
+        assert_equal(False,  self.is_fork_triggered_on_node(1))
+        assert_equal(False,  self.is_fork_triggered_on_node(2))
+        assert_equal(False,  self.is_fork_triggered_on_node(3))
+        print "Fork triggered successfully on node 0 (block height 100)"
+
+        # check node 1 triggering around height 200
+        self.nodes[1].generate(99)
+        assert_equal(False, self.is_fork_triggered_on_node(1))
+        self.nodes[1].generate(1)
+        assert_equal(True,  self.is_fork_triggered_on_node(1))
+        print "Fork triggered successfully on node 1 (block height 200)"
+
+        # check node 2 triggering around height 431
+        # it starts at 100
+        self.nodes[2].generate(330)
+        assert_equal(False, self.is_fork_triggered_on_node(2))
+        self.nodes[2].generate(1)
+        assert_equal(True,  self.is_fork_triggered_on_node(2))
+        # block 431 is when fork activation is performed.
+        # block 432 is first block where new consensus rules are in effect.
+        print "Fork triggered successfully on node 2 (segwit, height 431)"
+
+        # check node 3 triggering around height 300
+        # move to 299
+        self.nodes[3].generate(199)
+        assert_equal(False, self.is_fork_triggered_on_node(3))
+        self.nodes[3].generate(1)
+        assert_equal(True,  self.is_fork_triggered_on_node(3))
+        print "Fork triggered successfully on node 3 (block height 300 ahead of SegWit)"
 
 if __name__ == '__main__':
     MVF_TRIG_Test().main()

--- a/src/main.h
+++ b/src/main.h
@@ -459,7 +459,8 @@ bool CheckIndexAgainstCheckpoint(const CBlockIndex* pindexPrev, CValidationState
 bool AcceptBlock(CBlock& block, CValidationState& state, CBlockIndex **pindex, bool fRequested, CDiskBlockPos* dbp);
 bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state, CBlockIndex **ppindex= NULL);
 
-
+// MVF-BU added for TRIG
+bool IsWitnessEnabled(const CBlockIndex* pindexPrev, const Consensus::Params& params);
 
 class CBlockFileInfo
 {

--- a/src/mvf-bu.cpp
+++ b/src/mvf-bu.cpp
@@ -97,7 +97,7 @@ void ForkSetup(const CChainParams& chainparams)
 void ActivateFork(void)
 {
     LogPrintf("%s: MVF: checking whether to perform fork activation\n", __func__);
-    if (!isMVFHardForkActive)
+    if (!isMVFHardForkActive)  // sanity check
     {
         LogPrintf("%s: MVF: performing fork activation actions\n", __func__);
         isMVFHardForkActive = true;


### PR DESCRIPTION
Triggering is extending to include SegWit activation

A qa test (mvf-bu-trig.py) is added which so far covers only the activation during generation of a chain.

The test still needs to be extended to cover loading of the chain from disk at startup (again with various cases of block height and SegWit activation/non-activation).

De-activation is also not yet tested (although it falls under TRIG). The test may be split up in future to test these separate functionalities.
