### PR TITLE
Wallet backup is not re-created if node has already forked

### DIFF
--- a/qa/rpc-tests/walletbackupauto.py
+++ b/qa/rpc-tests/walletbackupauto.py
@@ -33,6 +33,14 @@ Then restored using the auto backup wallets eg wallet.dat.auto.114.bak.
 Sanity check to confirm 1/2/3/4 balances match the 114 block balances.
 Sanity check to confirm 5th node does NOT perform the auto backup
 and that the debug.log contains a conflict message
+
+Node 2 is rewinded to before the backup height, and a check is made that
+an existing backup is copied to a .old file with identical contents if the
+existing backup is overwritten.
+
+Finally, node 1 is stopped, its wallet backup is deleted, and the node is
+restarted. A post-fork block is generated to check that the wallet backup
+is not re-performed once the node has already forked.
 """
 
 import os
@@ -125,11 +133,9 @@ class WalletBackupTest(BitcoinTestFramework):
         stop_node(self.nodes[2], 2)
         stop_node(self.nodes[3], 3)
 
-    def erase_four(self):
-        os.remove(os.path.join(self.options.tmpdir,"node0","regtest","wallet.dat"))
-        os.remove(os.path.join(self.options.tmpdir,"node1","regtest","wallet.dat"))
-        os.remove(os.path.join(self.options.tmpdir,"node2","regtest","wallet.dat"))
-        os.remove(os.path.join(self.options.tmpdir,"node3","regtest","wallet.dat"))
+    def erase_hot_wallets(self):
+        for node in xrange(4):
+            os.remove(os.path.join(self.options.tmpdir,"node%s" % node,"regtest","wallet.dat"))
 
     def run_test(self):
         logging.info("Automatic backup configured for block %s"%(backupblock))
@@ -261,7 +267,7 @@ class WalletBackupTest(BitcoinTestFramework):
         ##
         logging.info("Switching wallets. Restoring using automatic wallet backups...")
         self.stop_four()
-        self.erase_four()
+        self.erase_hot_wallets()
 
         # Restore wallets from backup
         shutil.copyfile(node0backupfile, os.path.join(tmpdir,"node0","regtest","wallet.dat"))
@@ -331,6 +337,30 @@ class WalletBackupTest(BitcoinTestFramework):
         logging.info("Checksum ok - shutting down")
         stop_node(self.nodes[2], 2)
         self.start_four()
+
+        # test that wallet backup is not performed again if fork has already
+        # triggered and wallet exists
+        # (otherwise it would backup a later-state wallet)
+        logging.info("stopping node 1")
+        stop_node(self.nodes[1], 1)
+        logging.info("checking that wallet backup file exists: %s" % node1backupfile)
+        assert(os.path.isfile(node1backupfile))
+        logging.info("removing wallet backup file %s" % node1backupfile)
+        os.remove(node1backupfile)
+        # check that no wallet backup file created
+        logging.info("restarting node 1")
+        self.nodes[1] = start_node(1, self.options.tmpdir, ["-keypool=100",
+                                                            "-autobackupwalletpath=filenameonly.@.bak",
+                                                            "-autobackupblock=%s"%(backupblock)])
+        logging.info("generating another block on node 1")
+        self.nodes[1].generate(1)
+        logging.info("checking that backup file has not been created again...")
+        node1backupexists = 0
+        if os.path.isfile(node1backupfile):
+            node1backupexists = 1
+            logging.info("Error: Auto backup created again on node1 after fork has already activated!")
+        assert_equal(0, node1backupexists)
+
 
 if __name__ == '__main__':
     WalletBackupTest().main()

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -141,7 +141,7 @@ public:
         consensus.hashGenesisBlock = genesis.GetHash();
         // MVF-BU begin (MVHF-BU-DES-TRIG-3)
         // block height at which MVF-BU hard fork activates
-        consensus.nMVFActivateForkHeight = HARDFORK_HEIGHT_MAINNET;
+        consensus.nMVFDefaultActivateForkHeight = HARDFORK_HEIGHT_MAINNET;
         // MVF-BU end
 
         assert(consensus.hashGenesisBlock == uint256S("0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"));
@@ -248,7 +248,7 @@ public:
         consensus.hashGenesisBlock = genesis.GetHash();
         // MVF-BU begin (MVHF-BU-DES-TRIG-3)
         // block height at which MVF-BU hard fork activates
-        consensus.nMVFActivateForkHeight = HARDFORK_HEIGHT_NOLNET;
+        consensus.nMVFDefaultActivateForkHeight = HARDFORK_HEIGHT_NOLNET;
         // MVF-BU end
 
         //assert(consensus.hashGenesisBlock == uint256S("0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"));
@@ -336,7 +336,7 @@ public:
         consensus.hashGenesisBlock = genesis.GetHash();
         // MVF-BU begin (MVHF-BU-DES-TRIG-3)
         // block height at which MVF-BU hard fork activates
-        consensus.nMVFActivateForkHeight = HARDFORK_HEIGHT_TESTNET;
+        consensus.nMVFDefaultActivateForkHeight = HARDFORK_HEIGHT_TESTNET;
         // MVF-BU end
 
         assert(consensus.hashGenesisBlock == uint256S("0x000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"));
@@ -418,7 +418,7 @@ public:
         consensus.hashGenesisBlock = genesis.GetHash();
         // MVF-BU begin (MVHF-BU-DES-TRIG-3)
         // block height at which MVF-BU hard fork activates
-        consensus.nMVFActivateForkHeight = HARDFORK_HEIGHT_REGTEST;
+        consensus.nMVFDefaultActivateForkHeight = HARDFORK_HEIGHT_REGTEST;
         // MVF-BU end
 
         assert(consensus.hashGenesisBlock == uint256S("0x0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"));

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -64,9 +64,9 @@ struct Params {
     int64_t DifficultyAdjustmentInterval() const { return nPowTargetTimespan / nPowTargetSpacing; }
     int64_t SizeForkExpiration() const { return 1514764800; } // BU (classic compatibility) 2018-01-01 00:00:00 GMT
     // MVF-BU begin (MVHF-BU-DES-TRIG-3)
-    int nMVFActivateForkHeight;     // trigger block height
+    int nMVFDefaultActivateForkHeight;     // trigger block height
 
-    int MVFActivateForkHeight() const { return nMVFActivateForkHeight; };
+    int MVFDefaultActivateForkHeight() const { return nMVFDefaultActivateForkHeight; };
     // MVF-BU end
 
 };

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1666,10 +1666,14 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     }
     // MVF-BU begin
     else {
-        if (chainActive.Height() >= Params().GetConsensus().nMVFActivateForkHeight)
+        // check if we're past the auto backup block height or fork height
+        if (chainActive.Height() >= FinalActivateForkHeight
+            || chainActive.Height() > GetArg("-autobackupblock", FinalActivateForkHeight - 1))
+            // MVF-BU TODO: check if SegWit is already active at height. A bit tricky at this point since versionbitscache is in main.cpp.
         {
-            LogPrintf("MVF: AppInit2: ChainActive.Tip() exceeds fork activation height - do stuff?\n");
-            // MVF-BU TODO: perform any init actions needed
+            LogPrintf("MVF: AppInit2: ChainActive.Tip() exceeds fork activation height at startup - disabling wallet backup\n");
+            fAutoBackupDone = true;
+            // MVF-BU TODO: perform any other init actions needed
         }
     }
     // MVF-BU end

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -84,7 +84,6 @@ size_t nCoinCacheUsage = 5000 * 300;
 uint64_t nPruneTarget = 0;
 bool fAlerts = DEFAULT_ALERTS;
 bool fEnableReplacement = DEFAULT_ENABLE_REPLACEMENT;
-bool fAutoBackupDone = false; // MVHF-BU
 
 /** Fees smaller than this (in satoshi) are considered zero fee (for relaying, mining and transaction creation) */
 CFeeRate minRelayTxFee = CFeeRate(DEFAULT_MIN_RELAY_TX_FEE);

--- a/src/mvf-bu.cpp
+++ b/src/mvf-bu.cpp
@@ -19,6 +19,11 @@ int FinalForkId = 0;
 // track whether HF is active (MVHF-BU-DES-TRIG-5)
 bool isMVFHardForkActive = false;
 
+// track whether auto wallet backup might still need to be done
+// this is set to true at startup if client detects fork already triggered
+// otherwise when the backup is made. (MVHF-BU-DES-WABU-1)
+bool fAutoBackupDone = false;
+
 // default suffix to append to wallet filename for auto backup (MVHF-BU-DES-WABU-1)
 std::string autoWalletBackupSuffix = "auto.@.bak";
 
@@ -51,7 +56,7 @@ void ForkSetup(const CChainParams& chainparams)
 
     LogPrintf("%s: MVF: doing setup\n", __func__);
     LogPrintf("%s: MVF: active network = %s\n", __func__, activeNetworkID);
-    FinalActivateForkHeight = GetArg("-forkheight", chainparams.GetConsensus().nMVFActivateForkHeight);
+    FinalActivateForkHeight = GetArg("-forkheight", chainparams.GetConsensus().nMVFDefaultActivateForkHeight);
 
     // determine minimum fork height according to network
     // (these are set to the same as the default fork heights for now, but could be made different)
@@ -90,6 +95,7 @@ void ForkSetup(const CChainParams& chainparams)
 
     LogPrintf("%s: MVF: active fork height = %d\n", __func__, FinalActivateForkHeight);
     LogPrintf("%s: MVF: active fork id = 0x%06x (%d)\n", __func__, FinalForkId, FinalForkId);
+    LogPrintf("%s: MVF: auto backup block = %d\n", __func__, GetArg("-autobackupblock", FinalForkId - 1));
 }
 
 

--- a/src/mvf-bu.h
+++ b/src/mvf-bu.h
@@ -12,6 +12,8 @@ class CChainParams;
 
 extern int FinalActivateForkHeight;         // MVHF-BU-DES-TRIG-4
 extern bool isMVFHardForkActive;            // MVHF-BU-DES-TRIG-5
+extern int FinalForkId;                     // MVHF-BU-DES-CSIG-1
+extern bool fAutoBackupDone;                // MVHF-BU-DES-WABU-1
 extern std::string autoWalletBackupSuffix;  // MVHF-BU-DES-WABU-1
 
 


### PR DESCRIPTION
This includes code in the application and additional + modified test code in walletbackupauto.py.

Now, if a node detects at startup that it is already past the backup block height, it will not perform the auto backup again. The test has been extended to cover this case, and also needed to be modified in how it tests for the .old file generation (when an existing backup file is present in the same location when the backup is attempted).

Additionally, nMVFActivateForkHeight has been renamed nMVFDefaultActivateForkHeight to make it clearer that these only represent the default fork heights on the various networks.