### PR TITLE
add basic persistence using btcfork.conf file (MVHF-BU-DES-TRIG-10), getblockchaininfo RPC (MVHF-BU-DES-TRIG-9)

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -78,7 +78,7 @@ if EXEEXT == ".exe" and "-win" not in opts:
 testScripts = [
     'bip68-112-113-p2p.py',
     'wallet.py',
-    'mvf-bu-trig.py',
+    'mvf-bu-trig.py',  # MVF-BU
     'excessive.py',
     'listtransactions.py',
     'receivedby.py',
@@ -99,7 +99,7 @@ testScripts = [
     'fundrawtransaction.py',
     'signrawtransactions.py',
     'walletbackup.py',
-    'walletbackupauto.py', # MVHF-BU
+    'walletbackupauto.py',  # MVF-BU
     'nodehandling.py',
     'reindex.py',
     'decodescript.py',

--- a/qa/rpc-tests/walletbackupauto.py
+++ b/qa/rpc-tests/walletbackupauto.py
@@ -4,7 +4,7 @@
 # Copyright (c) 2016 The Bitcoin developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-# MVHF-BU
+# MVF-BU
 """
 See https://github.com/BTCfork/hardfork_prototype_1_mvf-bu/blob/master/doc/mvf-bu-test-design.md#411
 
@@ -312,6 +312,8 @@ class WalletBackupTest(BitcoinTestFramework):
         # rewind node 2's chain to before backupblock
         logging.info("Stopping all nodes")
         self.stop_four()
+        for n in xrange(4):
+            os.unlink(os.path.join(tmpdir,"node%s" % n,"btcfork.conf"))
         logging.info("Erasing blockchain on node 2 while keeping backup file")
         shutil.rmtree(self.options.tmpdir + "/node2/regtest/blocks")
         shutil.rmtree(self.options.tmpdir + "/node2/regtest/chainstate")
@@ -337,6 +339,7 @@ class WalletBackupTest(BitcoinTestFramework):
         assert_equal(node2backupfile_orig_md5,hashlib.md5(open(os.path.join(tmpdir,"node2","regtest","newreldir",old_files_found[0]), 'rb').read()).hexdigest())
         logging.info("Checksum ok - shutting down")
         stop_node(self.nodes[2], 2)
+        os.unlink(os.path.join(tmpdir,"node2","btcfork.conf"))
         self.start_four()
 
         # test that wallet backup is not performed again if fork has already
@@ -350,6 +353,7 @@ class WalletBackupTest(BitcoinTestFramework):
         os.remove(node1backupfile)
         # check that no wallet backup file created
         logging.info("restarting node 1")
+        os.unlink(os.path.join(tmpdir,"node1","btcfork.conf"))
         self.nodes[1] = start_node(1, self.options.tmpdir, ["-keypool=100",
                                                             "-autobackupwalletpath=filenameonly.@.bak",
                                                             "-autobackupblock=%s"%(backupblock)])

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1667,11 +1667,11 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     // MVF-BU begin
     else {
         // check if we're past the auto backup block height or fork height
-        if (chainActive.Height() >= FinalActivateForkHeight
+        if (wasMVFHardForkPreviouslyActivated || chainActive.Height() >= FinalActivateForkHeight
             || chainActive.Height() > GetArg("-autobackupblock", FinalActivateForkHeight - 1))
             // MVF-BU TODO: check if SegWit is already active at height. A bit tricky at this point since versionbitscache is in main.cpp.
         {
-            LogPrintf("MVF: AppInit2: ChainActive.Tip() exceeds fork activation height at startup - disabling wallet backup\n");
+            LogPrintf("MVF: AppInit2: Fork already activated or ChainActive.Tip() exceeds fork activation height at startup - disabling wallet backup\n");
             fAutoBackupDone = true;
             // MVF-BU TODO: perform any other init actions needed
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2837,7 +2837,7 @@ void static UpdateTip(CBlockIndex *pindexNew) {
     } // if (!fAutoBackupDone)
 
     // if trigger block height reached or SegWit soft-fork activated, perform hardfork activation actions (MVHF-BU-DES-TRIG-6)
-    if (!isMVFHardForkActive && ((chainActive.Height() == FinalActivateForkHeight)
+    if (!wasMVFHardForkPreviouslyActivated && !isMVFHardForkActive && ((chainActive.Height() == FinalActivateForkHeight)
                                    || VersionBitsTipState(chainParams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT) == THRESHOLD_ACTIVE))
     {
         // MVF-BU TODO: decide on above condition
@@ -4171,7 +4171,7 @@ bool static LoadBlockIndexDB()
 
     // MVF-BU begin
     // check if hardfork needs activating
-    if (!isMVFHardForkActive && (chainActive.Height() > FinalActivateForkHeight
+    if (!wasMVFHardForkPreviouslyActivated && !isMVFHardForkActive && (chainActive.Height() > FinalActivateForkHeight
                                  || VersionBitsTipState(chainparams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT) == THRESHOLD_ACTIVE))
     {
         ActivateFork();

--- a/src/mvf-bu.cpp
+++ b/src/mvf-bu.cpp
@@ -8,6 +8,10 @@
 #include "util.h"
 #include "chainparams.h"
 
+#include <iostream>
+#include <fstream>
+#include <boost/filesystem.hpp>
+
 using namespace std;
 
 // actual fork height, taking into account user configuration parameters (MVHF-BU-DES-TRIG-4)
@@ -15,6 +19,10 @@ int FinalActivateForkHeight = 0;
 
 // actual fork id, taking into account user configuration parameters (MVHF-BU-DES-CSIG-1)
 int FinalForkId = 0;
+
+// track whether HF has been activated before in previous run (MVHF-BU-DES-TRIG-5)
+// is set at startup based on btcfork.conf presence
+bool wasMVFHardForkPreviouslyActivated = false;
 
 // track whether HF is active (MVHF-BU-DES-TRIG-5)
 bool isMVFHardForkActive = false;
@@ -90,12 +98,25 @@ void ForkSetup(const CChainParams& chainparams)
         }
     }
 
-    // we should always set the activation flag to false during setup
-    isMVFHardForkActive = false;
-
     LogPrintf("%s: MVF: active fork height = %d\n", __func__, FinalActivateForkHeight);
     LogPrintf("%s: MVF: active fork id = 0x%06x (%d)\n", __func__, FinalForkId, FinalForkId);
     LogPrintf("%s: MVF: auto backup block = %d\n", __func__, GetArg("-autobackupblock", FinalForkId - 1));
+
+    // check if btcfork.conf exists (MVHF-BU-DES-TRIG-10)
+    boost::filesystem::path pathBTCforkConfigFile(BTCFORK_CONF_FILENAME);
+    if (!pathBTCforkConfigFile.is_complete())
+        pathBTCforkConfigFile = GetDataDir(false) / pathBTCforkConfigFile;
+    if (boost::filesystem::exists(pathBTCforkConfigFile)) {
+        LogPrintf("%s: MVF: found marker config file at %s - client has already forked before\n", __func__, pathBTCforkConfigFile.string().c_str());
+        wasMVFHardForkPreviouslyActivated = true;
+    }
+    else {
+        LogPrintf("%s: MVF: no marker config file at %s - client has not forked yet\n", __func__, pathBTCforkConfigFile.string().c_str());
+        wasMVFHardForkPreviouslyActivated = false;
+    }
+
+    // we should always set the activation flag to false during setup
+    isMVFHardForkActive = false;
 }
 
 
@@ -103,9 +124,38 @@ void ForkSetup(const CChainParams& chainparams)
 void ActivateFork(void)
 {
     LogPrintf("%s: MVF: checking whether to perform fork activation\n", __func__);
-    if (!isMVFHardForkActive)  // sanity check
+    if (!isMVFHardForkActive && !wasMVFHardForkPreviouslyActivated)  // sanity check
     {
         LogPrintf("%s: MVF: performing fork activation actions\n", __func__);
+
+        boost::filesystem::path pathBTCforkConfigFile(BTCFORK_CONF_FILENAME);
+        if (!pathBTCforkConfigFile.is_complete())
+            pathBTCforkConfigFile = GetDataDir(false) / pathBTCforkConfigFile;
+
+        LogPrintf("%s: MVF: checking for existence of %s\n", __func__, pathBTCforkConfigFile.string().c_str());
+
+        // remove btcfork.conf if it already exists - it shall be overwritten
+        if (boost::filesystem::exists(pathBTCforkConfigFile)) {
+            LogPrintf("%s: MVF: removing %s\n", __func__, pathBTCforkConfigFile.string().c_str());
+            try {
+                boost::filesystem::remove(pathBTCforkConfigFile);
+            } catch (const boost::filesystem::filesystem_error& e) {
+                LogPrintf("%s: Unable to remove pidfile: %s\n", __func__, e.what());
+            }
+        }
+        // try to write the btcfork.conf (MVHF-BU-DES-TRIG-10)
+        LogPrintf("%s: MVF: writing %s\n", __func__, pathBTCforkConfigFile.string().c_str());
+        std::ofstream  btcforkfile(pathBTCforkConfigFile.string().c_str(), std::ios::out);
+        btcforkfile << "forkheight=" << FinalActivateForkHeight << "\n";
+        btcforkfile << "forkid=" << FinalForkId << "\n";
+        btcforkfile << "autobackupblock=" << GetArg("-autobackupblock", FinalActivateForkHeight - 1) << "\n";
+        btcforkfile.close();
+
+        LogPrintf("%s: MVF: active fork height = %d\n", __func__, FinalActivateForkHeight);
+        LogPrintf("%s: MVF: active fork id = 0x%06x (%d)\n", __func__, FinalForkId, FinalForkId);
+        LogPrintf("%s: MVF: auto backup block = %d\n", __func__, GetArg("-autobackupblock", FinalForkId - 1));
+
+        // set the flag so that other code knows HF is active
         isMVFHardForkActive = true;
     }
 }

--- a/src/mvf-bu.h
+++ b/src/mvf-bu.h
@@ -10,11 +10,12 @@
 
 class CChainParams;
 
-extern int FinalActivateForkHeight;         // MVHF-BU-DES-TRIG-4
-extern bool isMVFHardForkActive;            // MVHF-BU-DES-TRIG-5
-extern int FinalForkId;                     // MVHF-BU-DES-CSIG-1
-extern bool fAutoBackupDone;                // MVHF-BU-DES-WABU-1
-extern std::string autoWalletBackupSuffix;  // MVHF-BU-DES-WABU-1
+extern int FinalActivateForkHeight;             // MVHF-BU-DES-TRIG-4
+extern bool wasMVFHardForkPreviouslyActivated;  // MVHF-BU-DES-TRIG-5
+extern bool isMVFHardForkActive;                // MVHF-BU-DES-TRIG-5
+extern int FinalForkId;                         // MVHF-BU-DES-CSIG-1
+extern bool fAutoBackupDone;                    // MVHF-BU-DES-WABU-1
+extern std::string autoWalletBackupSuffix;      // MVHF-BU-DES-WABU-1
 
 
 // default values that can be easily put into an enum
@@ -59,6 +60,8 @@ static const uint256 HARDFORK_POWRESET_MAINNET = uint256S("00007ffffffffffffffff
                      HARDFORK_POWRESET_NOLNET  = uint256S("3fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),  // nolnet
                      HARDFORK_POWRESET_REGTEST = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");  // regtestnet
 
+// MVF_BU-DES-TRIG-10 - config file that is written when forking, and used to detect "forked" condition at start
+const char * const BTCFORK_CONF_FILENAME = "btcfork.conf";
 
 extern std::string ForkCmdLineHelp();  // fork-specific command line option help (MVHF-BU-DES-TRIG-8)
 extern void ForkSetup(const CChainParams& chainparams);  // actions to perform at program setup (parameter validation etc.)

--- a/src/mvf-bu.h
+++ b/src/mvf-bu.h
@@ -12,6 +12,7 @@ class CChainParams;
 
 extern int FinalActivateForkHeight;         // MVHF-BU-DES-TRIG-4
 extern bool isMVFHardForkActive;            // MVHF-BU-DES-TRIG-5
+extern int FinalForkId;                     // MVHF-BU-DES-CSIG-1
 extern std::string autoWalletBackupSuffix;  // MVHF-BU-DES-WABU-1
 
 

--- a/src/mvf-bu.h
+++ b/src/mvf-bu.h
@@ -60,7 +60,7 @@ static const uint256 HARDFORK_POWRESET_MAINNET = uint256S("00007ffffffffffffffff
                      HARDFORK_POWRESET_NOLNET  = uint256S("3fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),  // nolnet
                      HARDFORK_POWRESET_REGTEST = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");  // regtestnet
 
-// MVF_BU-DES-TRIG-10 - config file that is written when forking, and used to detect "forked" condition at start
+// MVHF-BU-DES-TRIG-10 - config file that is written when forking, and used to detect "forked" condition at start
 const char * const BTCFORK_CONF_FILENAME = "btcfork.conf";
 
 extern std::string ForkCmdLineHelp();  // fork-specific command line option help (MVHF-BU-DES-TRIG-8)


### PR DESCRIPTION
## Add basic persistence using btcfork.conf file (MVHF-BU-DES-TRIG-10)

When fork is activated, a special config file, btcfork.conf, is written.
This file indicates to the software that the fork has taken place and that it should make some necessary adjustments to the normal node startup (e.g. connect to the forked network - not yet implemented).

Currently, the settings stored in the new config file are not yet read back in during program initialization. This might be necessary later on, to determine whether the forkport setting (to be added) matches the port setting or not. A mismatch would be an indication to prefer the forkport setting in order to connect to the forked network.
    
Whether or not the fork has been activated in a prior run is stored in the global variable 'wasMVFHardForkPreviouslyActivated'.
    
The mvf-bu-trig.py and walletbackupauto.py tests are extended:
- mvf-bu-trig.py now tests whether the fork file is written and the detection works
- the wallet backup tests remove the btcfork.conf prior to node restarts so that they can test the .old file writing correctly. If this is not done, the client will skip performing the backup, and so the .old file would not be tested.
    
In future, the application should probably output a message at startup/shutdown and in the GUI if it detects this file, to prompt the user to integrate the relevant settings into the main configuration file (bitcoin.conf).

## Add hardforks, SegWit output for getblockchaininfo RPC (MVHF-BU-DES-TRIG-9)

A 'hardforks' section is added in 'getblockchaininfo' RPC call output as long as the fork has not yet activated.