### PR TITLE
retriggering fixes backported from MVF-Core (TRIG)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2837,8 +2837,10 @@ void static UpdateTip(CBlockIndex *pindexNew) {
     } // if (!fAutoBackupDone)
 
     // if trigger block height reached or SegWit soft-fork activated, perform hardfork activation actions (MVHF-BU-DES-TRIG-6)
-    if (!wasMVFHardForkPreviouslyActivated && !isMVFHardForkActive && ((chainActive.Height() == FinalActivateForkHeight)
-                                   || VersionBitsTipState(chainParams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT) == THRESHOLD_ACTIVE))
+    // MVF-BU TODO: the block height test condition below uses strict equality - check if correct
+    // right now we haven't found a test case where >= would be needed, but we need to check if test coverage is inadequate
+    if (!isMVFHardForkActive && ((chainActive.Height() == FinalActivateForkHeight)
+                             || VersionBitsTipState(chainParams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT) == THRESHOLD_ACTIVE))
     {
         // MVF-BU TODO: decide on above condition
         // if preparations are only made after block has been accepted, then only FinalActivateForkHeight+1 can be new rules
@@ -4171,8 +4173,8 @@ bool static LoadBlockIndexDB()
 
     // MVF-BU begin
     // check if hardfork needs activating
-    if (!wasMVFHardForkPreviouslyActivated && !isMVFHardForkActive && (chainActive.Height() > FinalActivateForkHeight
-                                 || VersionBitsTipState(chainparams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT) == THRESHOLD_ACTIVE))
+    if (!isMVFHardForkActive && (chainActive.Height() >= FinalActivateForkHeight
+                             || VersionBitsTipState(chainparams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT) == THRESHOLD_ACTIVE))
     {
         ActivateFork();
     }

--- a/src/mvf-bu.cpp
+++ b/src/mvf-bu.cpp
@@ -124,7 +124,7 @@ void ForkSetup(const CChainParams& chainparams)
 void ActivateFork(void)
 {
     LogPrintf("%s: MVF: checking whether to perform fork activation\n", __func__);
-    if (!isMVFHardForkActive && !wasMVFHardForkPreviouslyActivated)  // sanity check
+    if (!isMVFHardForkActive && !wasMVFHardForkPreviouslyActivated)  // sanity check to protect the one-off actions
     {
         LogPrintf("%s: MVF: performing fork activation actions\n", __func__);
 
@@ -154,10 +154,10 @@ void ActivateFork(void)
         LogPrintf("%s: MVF: active fork height = %d\n", __func__, FinalActivateForkHeight);
         LogPrintf("%s: MVF: active fork id = 0x%06x (%d)\n", __func__, FinalForkId, FinalForkId);
         LogPrintf("%s: MVF: auto backup block = %d\n", __func__, GetArg("-autobackupblock", FinalForkId - 1));
-
-        // set the flag so that other code knows HF is active
-        isMVFHardForkActive = true;
     }
+    // set the flag so that other code knows HF is active
+    LogPrintf("%s: MVF: enabling isMVFHardForkActive\n", __func__);
+    isMVFHardForkActive = true;
 }
 
 
@@ -168,6 +168,7 @@ void DeactivateFork(void)
     if (isMVFHardForkActive)
     {
         LogPrintf("%s: MVF: performing fork deactivation actions\n", __func__);
-        isMVFHardForkActive = false;
     }
+    LogPrintf("%s: MVF: disabling isMVFHardForkActive\n", __func__);
+    isMVFHardForkActive = false;
 }


### PR DESCRIPTION
this now correctly enables isMVFHardForkActive when the fork was active previously

also fixed off-by-one error in LoadBlockIndexDB which resulted in fork being
activated one block later than through UpdateTip()

added a TODO to UpdateTip activation to remember to check if strict equality is the right thing to use in there (frankly, we don't have the re-org tests yet to check if its sufficient)