### PR TITLE
Triggering adjustments (set FinalActivateForkHeight) and wallet backup fixes, etc.

### DIFF
--- a/qa/rpc-tests/walletbackupauto.py
+++ b/qa/rpc-tests/walletbackupauto.py
@@ -69,22 +69,27 @@ class WalletBackupTest(BitcoinTestFramework):
         # and configure option autobackupwalletpath
         # testing each file path variant
         # as per the test design at sw-req-10-1
-        extra_args = [
+        self.extra_args = [
             ["-keypool=100",
                 "-autobackupwalletpath=%s"%(os.path.join(self.options.tmpdir,"node0","newabsdir","pathandfile.@.bak")),
+                "-forkheight=%s"%(backupblock+1),
                 "-autobackupblock=%s"%(backupblock)],
             ["-keypool=100",
                 "-autobackupwalletpath=filenameonly.@.bak",
+                "-forkheight=%s"%(backupblock+1),
                 "-autobackupblock=%s"%(backupblock)],
             ["-keypool=100",
                 "-autobackupwalletpath=" + os.path.join(".","newreldir"),
+                "-forkheight=%s"%(backupblock+1),
                 "-autobackupblock=%s"%(backupblock)],
-            ["-autobackupblock=%s"%(backupblock)],
+            ["-autobackupblock=%s"%(backupblock),
+                "-forkheight=%s"%(backupblock+1)],
             ["-disablewallet",
                 "-autobackupwalletpath="+ os.path.join(self.options.tmpdir,"node4"),
+                "-forkheight=%s"%(backupblock+1),
                 "-autobackupblock=%s"%(backupblock)]]
 
-        self.nodes = start_nodes(5, self.options.tmpdir, extra_args)
+        self.nodes = start_nodes(5, self.options.tmpdir, self.extra_args)
         connect_nodes(self.nodes[0], 3)
         connect_nodes(self.nodes[1], 3)
         connect_nodes(self.nodes[2], 3)
@@ -116,11 +121,8 @@ class WalletBackupTest(BitcoinTestFramework):
 
     # As above, this mirrors the original bash test.
     def start_four(self):
-
-        self.nodes[0] = start_node(0, self.options.tmpdir)
-        self.nodes[1] = start_node(1, self.options.tmpdir)
-        self.nodes[2] = start_node(2, self.options.tmpdir)
-        self.nodes[3] = start_node(3, self.options.tmpdir)
+        for i in range(4):
+            self.nodes[i] = start_node(i, self.options.tmpdir, self.extra_args[i])
 
         connect_nodes(self.nodes[0], 3)
         connect_nodes(self.nodes[1], 3)
@@ -243,6 +245,11 @@ class WalletBackupTest(BitcoinTestFramework):
         assert_equal(1, node2backupexists)
         assert_equal(1, node3backupexists)
 
+        # generate one more block to trigger the fork
+        self.nodes[3].generate(1)
+        self.sync_all()
+        assert_equal(self.nodes[0].getblockcount(),backupblock+1)
+
         ##
         # Calculate wallet balances for comparison after restore
         ##
@@ -318,7 +325,11 @@ class WalletBackupTest(BitcoinTestFramework):
         shutil.rmtree(self.options.tmpdir + "/node2/regtest/blocks")
         shutil.rmtree(self.options.tmpdir + "/node2/regtest/chainstate")
         logging.info("Restarting node 2")
-        self.nodes[2] = start_node(2, self.options.tmpdir,["-keypool=100", "-autobackupwalletpath="+ os.path.join(".","newreldir"), "-autobackupblock=%s"%(backupblock) ])
+        self.nodes[2] = start_node(2, self.options.tmpdir,["-keypool=100",
+                                                           "-autobackupwalletpath="+ os.path.join(".","newreldir"),
+                                                           "-forkheight=%s"%(backupblock+1),
+                                                           "-autobackupblock=%s"%(backupblock) ])
+
         # check that there is no .old yet (node 2 needs to generate a block to hit the height)
         old_files_found=[]
         for file in os.listdir(os.path.join(tmpdir,"node2","regtest","newreldir")):
@@ -337,6 +348,8 @@ class WalletBackupTest(BitcoinTestFramework):
         # (the file should just have been renamed)
         logging.info("Checking .old file %s" % old_files_found[0])
         assert_equal(node2backupfile_orig_md5,hashlib.md5(open(os.path.join(tmpdir,"node2","regtest","newreldir",old_files_found[0]), 'rb').read()).hexdigest())
+        # generate the fork block
+        self.nodes[2].generate(backupblock+1)
         logging.info("Checksum ok - shutting down")
         stop_node(self.nodes[2], 2)
         os.unlink(os.path.join(tmpdir,"node2","btcfork.conf"))
@@ -356,6 +369,7 @@ class WalletBackupTest(BitcoinTestFramework):
         os.unlink(os.path.join(tmpdir,"node1","btcfork.conf"))
         self.nodes[1] = start_node(1, self.options.tmpdir, ["-keypool=100",
                                                             "-autobackupwalletpath=filenameonly.@.bak",
+                                                            "-forkheight=%s"%(backupblock+1),
                                                             "-autobackupblock=%s"%(backupblock)])
         logging.info("generating another block on node 1")
         self.nodes[1].generate(1)

--- a/qa/rpc-tests/walletbackupauto.py
+++ b/qa/rpc-tests/walletbackupauto.py
@@ -121,13 +121,8 @@ class WalletBackupTest(BitcoinTestFramework):
 
     # As above, this mirrors the original bash test.
     def start_four(self):
-
         for i in range(4):
             self.nodes[i] = start_node(i, self.options.tmpdir, self.extra_args[i])
-
-        #self.nodes[1] = start_node(1, self.options.tmpdir)
-        #self.nodes[2] = start_node(2, self.options.tmpdir)
-        #self.nodes[3] = start_node(3, self.options.tmpdir)
 
         connect_nodes(self.nodes[0], 3)
         connect_nodes(self.nodes[1], 3)

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -64,7 +64,7 @@ struct Params {
     int64_t nPowTargetSpacing;
     int64_t nPowTargetTimespan;
 
-    int MVFRetargetPeriodEnd() const { return  FinalActivateForkHeight + (180 * 24 * 60 * 60 / nPowTargetSpacing); }
+    int MVFRetargetPeriodEnd() const { return FinalActivateForkHeight + HARDFORK_RETARGET_BLOCKS; }
 
     // return height-dependent target time span used to compute retargeting interval (MVHF-BU-DES-DIAD-4)
     int64_t MVFPowTargetTimespan(int Height) const

--- a/src/mvf-bu.cpp
+++ b/src/mvf-bu.cpp
@@ -7,6 +7,7 @@
 #include "init.h"
 #include "util.h"
 #include "chainparams.h"
+#include "validationinterface.h"
 
 #include <iostream>
 #include <fstream>
@@ -101,7 +102,7 @@ void ForkSetup(const CChainParams& chainparams)
 
     LogPrintf("%s: MVF: active fork height = %d\n", __func__, FinalActivateForkHeight);
     LogPrintf("%s: MVF: active fork id = 0x%06x (%d)\n", __func__, FinalForkId, FinalForkId);
-    LogPrintf("%s: MVF: auto backup block = %d\n", __func__, GetArg("-autobackupblock", FinalForkId - 1));
+    LogPrintf("%s: MVF: auto backup block = %d\n", __func__, GetArg("-autobackupblock", FinalActivateForkHeight - 1));
 
     // check if btcfork.conf exists (MVHF-BU-DES-TRIG-10)
     boost::filesystem::path pathBTCforkConfigFile(BTCFORK_CONF_FILENAME);
@@ -122,12 +123,18 @@ void ForkSetup(const CChainParams& chainparams)
 
 
 /** Actions when the fork triggers (MVHF-BU-DES-TRIG-6) */
-void ActivateFork(void)
+// doBackup parameter default is true
+void ActivateFork(int actualForkHeight, bool doBackup)
 {
     LogPrintf("%s: MVF: checking whether to perform fork activation\n", __func__);
     if (!isMVFHardForkActive && !wasMVFHardForkPreviouslyActivated)  // sanity check to protect the one-off actions
     {
         LogPrintf("%s: MVF: performing fork activation actions\n", __func__);
+
+        // set so that we capture the actual height at which it forked
+        // because this can be different from user-specified configuration
+        // (e.g. soft-fork activated)
+        FinalActivateForkHeight = actualForkHeight;
 
         boost::filesystem::path pathBTCforkConfigFile(BTCFORK_CONF_FILENAME);
         if (!pathBTCforkConfigFile.is_complete())
@@ -149,12 +156,53 @@ void ActivateFork(void)
         std::ofstream  btcforkfile(pathBTCforkConfigFile.string().c_str(), std::ios::out);
         btcforkfile << "forkheight=" << FinalActivateForkHeight << "\n";
         btcforkfile << "forkid=" << FinalForkId << "\n";
-        btcforkfile << "autobackupblock=" << GetArg("-autobackupblock", FinalActivateForkHeight - 1) << "\n";
-        btcforkfile.close();
 
         LogPrintf("%s: MVF: active fork height = %d\n", __func__, FinalActivateForkHeight);
         LogPrintf("%s: MVF: active fork id = 0x%06x (%d)\n", __func__, FinalForkId, FinalForkId);
-        LogPrintf("%s: MVF: auto backup block = %d\n", __func__, GetArg("-autobackupblock", FinalForkId - 1));
+
+        // MVF-BU begin MVHF-BU-DES-WABU-3
+        // check if we need to do wallet auto backup at fork block
+        // this is in case of soft-fork triggered activation
+        // MVF-BU TODO: reduce code duplication between this block and main.cpp:UpdateTip()
+        if (doBackup && !fAutoBackupDone)
+        {
+            std::string strWalletBackupFile = GetArg("-autobackupwalletpath", "");
+            int BackupBlock = actualForkHeight;
+
+            //LogPrintf("MVF DEBUG: autobackupwalletpath=%s\n",strWalletBackupFile);
+            //LogPrintf("MVF DEBUG: autobackupblock=%d\n",BackupBlock);
+
+            if (GetBoolArg("-disablewallet", false))
+            {
+                LogPrintf("MVF: -disablewallet and -autobackupwalletpath conflict so automatic backup disabled.");
+                fAutoBackupDone = true;
+            }
+            else {
+                // Auto Backup defined, but no need to check block height since
+                // this is fork activation time and we still have not backed up
+                // so just get on with it
+                if (GetMainSignals().BackupWalletAuto(strWalletBackupFile, BackupBlock))
+                    fAutoBackupDone = true;
+                else {
+                    // shutdown in case of wallet backup failure (MVHF-BU-DES-WABU-5)
+                    // MVF-BU TODO: investigate if this is safe in terms of wallet flushing/closing or if more needs to be done
+                    btcforkfile << "error: unable to perform automatic backup - exiting" << "\n";
+                    btcforkfile.close();
+                    throw std::runtime_error("CWallet::BackupWalletAuto() : Auto wallet backup failed!");
+                }
+            }
+            btcforkfile << "autobackupblock=" << FinalActivateForkHeight << "\n";
+            LogPrintf("%s: MVF: soft-forked auto backup block = %d\n", __func__, FinalActivateForkHeight);
+
+        }
+        else {
+            // auto backup was already made pre-fork - emit parameters
+            btcforkfile << "autobackupblock=" << GetArg("-autobackupblock", FinalActivateForkHeight - 1) << "\n";
+            LogPrintf("%s: MVF: height-based auto backup block = %d\n", __func__, GetArg("-autobackupblock", FinalActivateForkHeight - 1));
+        }
+
+        // close fork parameter file
+        btcforkfile.close();
     }
     // set the flag so that other code knows HF is active
     LogPrintf("%s: MVF: enabling isMVFHardForkActive\n", __func__);

--- a/src/mvf-bu.h
+++ b/src/mvf-bu.h
@@ -27,6 +27,10 @@ HARDFORK_HEIGHT_TESTNET = 9999999,   // public test network trigger height
 HARDFORK_HEIGHT_NOLNET  = 8888888,   // BU public no-limit test network  trigger height
 HARDFORK_HEIGHT_REGTEST =     100,   // regression test network (local)  trigger height
 
+// MVHF-BU-DES-DIAD-3 / MVHF-BU-DES-DIAD-4
+// period (in blocks) from fork activation until retargeting returns to normal
+HARDFORK_RETARGET_BLOCKS = 25920,    // 180*144 blocks
+
 // MVHF-BU-DES-NSEP-1 - network separation parameter defaults
 // MVF-BU TODO: re-check that these port values could be used
 HARDFORK_PORT_MAINNET = 9442,        // default post-fork port on operational network (mainnet)
@@ -65,7 +69,7 @@ const char * const BTCFORK_CONF_FILENAME = "btcfork.conf";
 
 extern std::string ForkCmdLineHelp();  // fork-specific command line option help (MVHF-BU-DES-TRIG-8)
 extern void ForkSetup(const CChainParams& chainparams);  // actions to perform at program setup (parameter validation etc.)
-extern void ActivateFork(void);    // actions to perform at fork triggering (MVHF-BU-DES-TRIG-6)
+extern void ActivateFork(int actualForkHeight, bool doBackup=true);  // actions to perform at fork triggering (MVHF-BU-DES-TRIG-6)
 extern void DeactivateFork(void);  // actions to revert if reorg deactivates fork (MVHF-BU-DES-TRIG-7)
 
 #endif

--- a/src/mvf-bu.h
+++ b/src/mvf-bu.h
@@ -27,6 +27,10 @@ HARDFORK_HEIGHT_TESTNET = 9999999,   // public test network trigger height
 HARDFORK_HEIGHT_NOLNET  = 8888888,   // BU public no-limit test network  trigger height
 HARDFORK_HEIGHT_REGTEST =     100,   // regression test network (local)  trigger height
 
+// MVHF-BU-DES-DIAD-3 / MVHF-BU-DES-DIAD-4
+// period (in blocks) from fork activation until retargeting returns to normal
+HARDFORK_RETARGET_BLOCKS = 25920,    // 180*144 blocks
+
 // MVHF-BU-DES-NSEP-1 - network separation parameter defaults
 // MVF-BU TODO: re-check that these port values could be used
 HARDFORK_PORT_MAINNET = 9442,        // default post-fork port on operational network (mainnet)

--- a/src/mvf-bu.h
+++ b/src/mvf-bu.h
@@ -69,7 +69,7 @@ const char * const BTCFORK_CONF_FILENAME = "btcfork.conf";
 
 extern std::string ForkCmdLineHelp();  // fork-specific command line option help (MVHF-BU-DES-TRIG-8)
 extern void ForkSetup(const CChainParams& chainparams);  // actions to perform at program setup (parameter validation etc.)
-extern void ActivateFork(void);    // actions to perform at fork triggering (MVHF-BU-DES-TRIG-6)
+extern void ActivateFork(int actualForkHeight, bool doBackup=true);  // actions to perform at fork triggering (MVHF-BU-DES-TRIG-6)
 extern void DeactivateFork(void);  // actions to revert if reorg deactivates fork (MVHF-BU-DES-TRIG-7)
 
 #endif


### PR DESCRIPTION
This PR covers some necessary fixes to the way we handle wallet backup.

Wallet backup is now also checked+done (if necessary) in ActivateFork(). This is done so that the wallet is backed up even if the fork is triggered by SegWit before the fork height or auto backup block height are reached. That's what users will expect - a reliable backup when the fork triggers. This also matches the requirements MVHF-BU-USER-REQ-10 and its children.

The wallet backup check in UpdateTip() remains, so that wallet backups on specific pre-fork blocks can still be done as before. However, the check and possible triggering of ActivateFork() is moved in front of the wallet backup check in UpdateTip(), and if necessary pre-empts it.

The fork activation now sets FinalActivateForkHeight to the actual fork height, so other functions like the difficulty retargeting periods should work correctly even if the fork is triggered by SegWit. The actual fork height + actual backup block height are now also written correctly to btcfork.conf when the fork triggers.

Other changes include adaptation of the wallet backup test to take into account that triggering the fork before the wallet backup block no longer works the same way (therefore the forkheight was shifted to autobackupblock+1.

FUTURE WORK

The wallet backup test may need to be extended with another node test run where the node forkheight < autobackupblock , to check that it backs up correctly at the fork point and not again at the autobackupblock when the fork is already active.

A "backup on SegWit activation" test case should also be included - this should now work due to the wallet backup code being called in ActivateFork().