### PR TITLE
workarounds for bip68-112-113-p2p and invalidtxrequest tests (prevent fork interference)

### DIFF
--- a/qa/rpc-tests/bip68-112-113-p2p.py
+++ b/qa/rpc-tests/bip68-112-113-p2p.py
@@ -101,8 +101,10 @@ class BIP68_112_113Test(ComparisonTestFramework):
 
     def setup_network(self):
         # Must set the blockversion for this test
+        # MVF-BU TODO: clarify why fork diff reset to 0x207eeeee at default forkheight 100 produces interference with this test
+        #              once that problem is sorted out, remove the forkheight parameter again
         self.nodes = start_nodes(1, self.options.tmpdir,
-                                 extra_args=[['-debug', '-whitelist=127.0.0.1', '-blockversion=4']],
+                                 extra_args=[['-forkheight=999999', '-debug', '-whitelist=127.0.0.1', '-blockversion=4']],
                                  binary=[self.options.testbinary])
 
     def run_test(self):

--- a/qa/rpc-tests/invalidtxrequest.py
+++ b/qa/rpc-tests/invalidtxrequest.py
@@ -7,6 +7,7 @@
 from test_framework.test_framework import ComparisonTestFramework
 from test_framework.comptool import TestManager, TestInstance, RejectResult
 from test_framework.blocktools import *
+from test_framework.util import start_nodes
 import time
 
 
@@ -21,6 +22,16 @@ class InvalidTxRequestTest(ComparisonTestFramework):
         Change the "outcome" variable from each TestInstance object to only do the comparison. '''
     def __init__(self):
         self.num_nodes = 1
+
+    # MVF-BU begin added setup_network to work around default regtest fork height interference with this test
+    # MVF-BU TODO: clarify why fork diff reset to 0x207eeeee at default forkheight 100 produces interference with this test
+    #              once that problem is sorted out, remove the forkheight parameter again
+    #              for now, set the forkheight to workaround this interference.
+    def setup_network(self):
+        self.nodes = start_nodes(1, self.options.tmpdir,
+                                 extra_args=[['-forkheight=999999', '-debug', '-whitelist=127.0.0.1', ]],
+                                 binary=[self.options.testbinary])
+    # MVF-BU end
 
     def run_test(self):
         test = TestManager(self, self.options.tmpdir)


### PR DESCRIPTION
This PR adds workarounds for two failing tests which are sensitive to interference of the fork since 0x207eeeee reset introduced in c12e3a6ecf0e1e0c1b29ad4dbc7f3c7dd5f874a8 .

Specific forkheight parameters have been added to move the fork activation outside the scope of these tests.

It is still unclear why the regtest reset to 0x207eeeee (chosen specifically to discern the fork activation difficulty) causes these tests (both of which use ComparisonTestFramework) to fail. This will be investigated in a separate activity.