### PR TITLE
Req7/forkresetwork

### DIFF
--- a/qa/rpc-tests/mvf-bu-retarget.py
+++ b/qa/rpc-tests/mvf-bu-retarget.py
@@ -13,6 +13,9 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 from test_framework.arith import *
 from random import randint
+seed = time.time()
+random.seed(seed)
+print "Random seed: %d " % seed
 
 # period (in blocks) from fork activation until retargeting returns to normal
 # MVF-BU TODO: Revert to 180*144

--- a/qa/rpc-tests/mvf-bu-retarget.py
+++ b/qa/rpc-tests/mvf-bu-retarget.py
@@ -11,12 +11,61 @@
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
+from test_framework.arith import *
 from random import randint
-import decimal
+import math, decimal
+
+l = math.log
+e = math.e
 
 # period (in blocks) from fork activation until retargeting returns to normal
-HARDFORK_RETARGET_BLOCKS = 90*144
-FORK_BLOCK = 2017
+# MVF-BU TODO: Revert to 180*144
+HARDFORK_RETARGET_BLOCKS = 90*144    # the period when retargeting returns to original
+FORK_BLOCK = 2017                    # needs to be >= 2017 to test fork difficulty reset
+POW_LIMIT = 0x207fffff
+PREFORK_BLOCKTIME = 1                # before the fork need to track the ActualTimespan
+
+def CalcForkResetWorkRequired(bits):
+    # Returns difficulty using the fork reset formula in pow.cpp:CalcForkResetTarget()
+    bnPowLimit = bits2target_int(hex2bin(int2hex(POW_LIMIT)))
+    # drop difficulty via factor
+    nDropFactor = 4
+    # total blocktimes prefork during run_test
+    nActualTimespan = (FORK_BLOCK * PREFORK_BLOCKTIME) - PREFORK_BLOCKTIME
+    # used reduced target time span while within the re-target period
+    nTargetTimespan = nActualTimespan / nDropFactor
+
+    # compare with debug.log
+    print "nTargetTimespan %d nActualTimespan=%d" % (nTargetTimespan,nActualTimespan)
+
+    bnOld = bits2target_int(hex2bin(bits))     # SetCompact
+    bnNew1 = bnOld / nTargetTimespan
+    bnNew2 = bnNew1 * nActualTimespan
+
+    # check for overflow or overlimit
+    if (bnNew2 / nActualTimespan != bnNew1 or bnNew2 > bnPowLimit):
+        bnNew = bnPowLimit
+    else:
+        bnNew = bnNew2
+
+    nBitsReset = int("0x%s" % bin2hex(target_int2bits(bnNew)),0) # GetCompact
+    return nBitsReset
+
+# formula debug testing
+# useful for testing whenever the reset formula changes pow.cpp:CalcForkResetTarget()
+##bits = "1d00ffff" # 1.000000000
+#bits = "201fffff" # 0.0000000019
+##bits = "203ffff6" # 0.0000000009
+##bits = "1f03f355" # 0.0000038624
+
+#print "before: 0x%s = %.10f" % (bits,bits2difficulty(int("0x%s"%bits,0)))
+
+#reset = CalcForkResetWorkRequired(bits)
+#diff = bits2difficulty(reset)
+#print "after : 0x%s = %.10f" % (int2hex(reset),diff)
+#raw_input()
+#assert_equal(0,1)
+# end debug testing
 
 class MVF_RETARGET_Test(BitcoinTestFramework):
 
@@ -40,22 +89,20 @@ class MVF_RETARGET_Test(BitcoinTestFramework):
         return (len(hf_active) > 0 and len(fork_actions_performed) == 1)
 
     def run_test(self):
-        # check that fork does not triggered before the height
+        # check that fork does not trigger before the forkheight
         print "Generating %s pre-fork blocks" % (FORK_BLOCK - 1)
-
+        #block0 already exists
         for n in range(FORK_BLOCK - 1):
             # Change block times so that difficulty develops
             best_block = self.nodes[0].getblock(self.nodes[0].getbestblockhash(), True)
-            #print "%s %s" %(
-                #best_block['height'],
-                #time.strftime("%Y-%m-%d %H:%M",time.gmtime(best_block['time'])))
-            self.nodes[0].setmocktime(best_block['time'] + 600)
+            self.nodes[0].setmocktime(best_block['time'] + PREFORK_BLOCKTIME)
             self.nodes[0].generate(1)
 
         # Read difficulty before the fork
         best_block = self.nodes[0].getblock(self.nodes[0].getbestblockhash(), True)
-        print "Pre-fork difficulty: %s %s " % (round(best_block['difficulty'],8), best_block['bits'])
-        best_diff_expected = best_block['difficulty'] / 10
+        print "Pre-fork difficulty: %.10f %s " % (best_block['difficulty'], best_block['bits'])
+        reset_diff_expected = bits2difficulty(CalcForkResetWorkRequired(best_block['bits']))
+        assert_greater_than(reset_diff_expected, 0)
 
         # Test fork did not trigger prematurely
         assert_equal(False, self.is_fork_triggered_on_node(0))
@@ -66,7 +113,15 @@ class MVF_RETARGET_Test(BitcoinTestFramework):
         self.nodes[0].setmocktime(best_block['time'] + 600)
         self.nodes[0].generate(1)
         assert_equal(True,   self.is_fork_triggered_on_node(0))
+
+        best_block = self.nodes[0].getblock(self.nodes[0].getbestblockhash(), True)
         print "Fork triggered successfully (block height %s)" % FORK_BLOCK
+
+        # Test fork difficulty reset
+        #print "expected = %.10f" % reset_diff_expected
+        assert_equal(round(best_block['difficulty'],10),round(reset_diff_expected,10))
+        #assert_equal(best_block['bits'], "207eeeee") # fixed reset
+        print "Post-fork difficulty reset success: %.10f %s " % (best_block['difficulty'], best_block['bits'])
 
         # use to track how many times the same bits are used in a row
         prev_block = 0
@@ -74,23 +129,15 @@ class MVF_RETARGET_Test(BitcoinTestFramework):
         next_block_time = 0
         count_bits_used = 0
         prev_block_delta = 0
-        best_diff_expected = 0
         prev_blocks_delta_avg = 0
         diff_factor = 0
 
         # start generating MVF blocks with varying time stamps
-        for n in xrange(HARDFORK_RETARGET_BLOCKS + 2016):
-            best_block_hash = self.nodes[0].getbestblockhash()
-            best_block = self.nodes[0].getblock(best_block_hash, True)
-
+        for n in xrange(HARDFORK_RETARGET_BLOCKS + 2017):
+            best_block = self.nodes[0].getblock(self.nodes[0].getbestblockhash(), True)
             prev_block = self.nodes[0].getblock(best_block['previousblockhash'], True)
 
-            # test fork difficult reset
             if best_block['height'] == FORK_BLOCK + 1 :
-                #assert_equal(round(best_block['difficulty'],8), round(best_diff_expected,8))
-                assert_equal(best_block['bits'], "207eeeee")
-                print "Post-fork difficulty reset successfull: %s %s " % (round(best_diff_expected,8), best_block['bits'])
-
                 # print column titles
                 print "nBits changed @ Time,Block,Delta(secs),nBits,Used,DiffInterval,Difficulty,NextDifficulty,DiffFactor"
             # end if best_block['height'] == FORK_BLOCK + 1
@@ -105,7 +152,7 @@ class MVF_RETARGET_Test(BitcoinTestFramework):
                 diff_factor = 600 / decimal.Decimal(prev_blocks_delta_avg)
                 best_diff_expected = prev_block['difficulty'] * diff_factor
 
-                print "%s,%d,%d,%s,%d,%d,%f,%f,%f " %(
+                print "%s,%d,%d,%s,%d,%d,%.8f,%.8f,%.4f " %(
                     time.strftime("%Y-%m-%d %H:%M",time.gmtime(prev_block['time'])),
                     prev_block['height'],
                     prev_blocks_delta_avg,
@@ -119,7 +166,7 @@ class MVF_RETARGET_Test(BitcoinTestFramework):
 
                 # Test processed bits are used within the expected difficulty interval
                 # except when the bits is at the bits limit: 207fffff
-                if prev_block['bits'] <> "207fffff":
+                if int("0x%s"%prev_block['bits'],0) <> POW_LIMIT :
                     assert_less_than_equal(count_bits_used, diffadjinterval)
 
                 # Test difficulty
@@ -140,10 +187,14 @@ class MVF_RETARGET_Test(BitcoinTestFramework):
                 next_block_time = 1200
             elif n in range(26,500) :
                 next_block_time = 600
-            elif n in range(500,2500) :
-                # simulate slow blocks just after the fork i.e. low hash power/high difficulty
-                # this will cause bits to hit the limit 207fffff
-                next_block_time = randint(4000,6000)
+            elif n in range(500,2000) :
+                # simulate slow blocks
+                # this will cause bits to hit the limit POW_LIMIT
+                next_block_time = randint(1000,3000)
+            elif n in range(2000,2500) :
+                # simulate faster blocks
+                # this will cause bits to hit the limit POW_LIMIT
+                next_block_time = randint(100,300)
             else:
                 # simulate ontime blocks i.e. hash power/difficult around 600 secs
                 next_block_time = randint(500,700)
@@ -156,17 +207,17 @@ class MVF_RETARGET_Test(BitcoinTestFramework):
 
             # Test the interval matches the interval defined in params.MVFPowTargetTimespan()
             if n in range(0,11) :
-                diff_interval_expected = 1
+                diff_interval_expected = 1     # 10 mins
             elif n in range(11,44) :
-                diff_interval_expected = 3
+                diff_interval_expected = 3     # 30 mins
             elif n in range(44,102) :
-                diff_interval_expected = 6
+                diff_interval_expected = 6     # 1 hour
             elif n in range(102,2012) :
-                diff_interval_expected = 18
-            elif n in range(2012,HARDFORK_RETARGET_BLOCKS) :
-                diff_interval_expected = 72
+                diff_interval_expected = 18    # 3 hours
+            elif n in range(2012,HARDFORK_RETARGET_BLOCKS+1) :
+                diff_interval_expected = 72    # 12 hours
             else:
-                diff_interval_expected = 2016
+                diff_interval_expected = 2016  # 14 days original
 
             #print "%d %d" % (diff_interval_expected, diffadjinterval)
             #if diff_interval_expected <> diffadjinterval : raw_input()

--- a/qa/rpc-tests/mvf-bu-retarget.py
+++ b/qa/rpc-tests/mvf-bu-retarget.py
@@ -13,25 +13,64 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 from test_framework.arith import *
 from random import randint
-import math, decimal
-
-l = math.log
-e = math.e
 
 # period (in blocks) from fork activation until retargeting returns to normal
 # MVF-BU TODO: Revert to 180*144
 HARDFORK_RETARGET_BLOCKS = 90*144    # the period when retargeting returns to original
-FORK_BLOCK = 2017                    # needs to be >= 2017 to test fork difficulty reset
+FORK_BLOCK = 2020                    # needs to be >= 2018 to test fork difficulty reset
 POW_LIMIT = 0x207fffff
-PREFORK_BLOCKTIME = 1                # before the fork need to track the ActualTimespan
+PREFORK_BLOCKTIME = 1                # before the fork during the regtest
+ORIGINAL_DIFFADJINTERVAL = 2016      # the original difficulty adjustment interval
+STANDARD_BLOCKTIME = 600             # the standard target seconds for a block
 
-def CalcForkResetWorkRequired(bits):
-    # Returns difficulty using the fork reset formula in pow.cpp:CalcForkResetTarget()
+def CalculateMVFNextWorkRequired(bits, actualBlockTimeSecs, targetBlockInterval):
+    # Returns difficulty using the fork reset formula in pow.cpp:CalculateMVFNextWorkRequired()
+
+    bnPowLimit = bits2target_int(hex2bin(int2hex(POW_LIMIT))) # MVF-BU moved here
+
+    # Limit adjustment step
+    nActualTimespan = actualBlockTimeSecs
+
+    # Target by interval
+    nTargetTimespan = targetBlockInterval * STANDARD_BLOCKTIME
+
+    # permit abrupt changes for a few blocks after the fork i.e. when nTargetTimespan is < 30 minutes (MVHF-BU-DES-DIAD-5)
+    if (nTargetTimespan >= STANDARD_BLOCKTIME * 3) :
+        # prevent abrupt changes to target
+        if (nActualTimespan < nTargetTimespan/4) :
+            nActualTimespan = nTargetTimespan/4
+        if (nActualTimespan > nTargetTimespan*4) :
+            nActualTimespan = nTargetTimespan*4
+
+    # compare with debug.log
+    #print "nTargetTimespan=%d nActualTimespan=%d" % (nTargetTimespan,nActualTimespan)
+
+    # Retarget
+    bnOld = bits2target_int(hex2bin(bits))     # SetCompact
+    # MVF-BU begin: move division before multiplication
+    # at regtest difficulty, the multiplication is prone to overflowing
+    bnNew1 = bnOld / nTargetTimespan
+    bnNew2 = bnNew1 * nActualTimespan
+
+    # Test for overflow
+    if (bnNew2 / nActualTimespan != bnNew1 or bnNew2 > bnPowLimit):
+        bnNew = bnPowLimit
+    else :
+        bnNew = bnNew2
+
+    newBits = "0x%s" % bin2hex(target_int2bits(bnNew)) # GetCompact
+    nBitsReset = int(newBits,0)
+    return nBitsReset
+
+
+def CalculateMVFResetWorkRequired(bits):
+    # Returns difficulty using the fork reset formula in pow.cpp:CalculateMVFResetWorkRequired()
+
     bnPowLimit = bits2target_int(hex2bin(int2hex(POW_LIMIT)))
     # drop difficulty via factor
     nDropFactor = 4
     # total blocktimes prefork during run_test
-    nActualTimespan = (FORK_BLOCK * PREFORK_BLOCKTIME) - PREFORK_BLOCKTIME
+    nActualTimespan = ORIGINAL_DIFFADJINTERVAL * PREFORK_BLOCKTIME
     # used reduced target time span while within the re-target period
     nTargetTimespan = nActualTimespan / nDropFactor
 
@@ -54,13 +93,14 @@ def CalcForkResetWorkRequired(bits):
 # formula debug testing
 # useful for testing whenever the reset formula changes pow.cpp:CalcForkResetTarget()
 ##bits = "1d00ffff" # 1.000000000
-#bits = "201fffff" # 0.0000000019
+##bits = "201fffff" # 0.0000000019
 ##bits = "203ffff6" # 0.0000000009
 ##bits = "1f03f355" # 0.0000038624
-
+#bits = "1e132d35"  # 1e19919b 0.0001527719
 #print "before: 0x%s = %.10f" % (bits,bits2difficulty(int("0x%s"%bits,0)))
 
-#reset = CalcForkResetWorkRequired(bits)
+##reset = CalculateMVFResetWorkRequired(bits)
+#reset = CalculateMVFNextWorkRequired(bits,800,1)
 #diff = bits2difficulty(reset)
 #print "after : 0x%s = %.10f" % (int2hex(reset),diff)
 #raw_input()
@@ -101,7 +141,9 @@ class MVF_RETARGET_Test(BitcoinTestFramework):
         # Read difficulty before the fork
         best_block = self.nodes[0].getblock(self.nodes[0].getbestblockhash(), True)
         print "Pre-fork difficulty: %.10f %s " % (best_block['difficulty'], best_block['bits'])
-        reset_diff_expected = bits2difficulty(CalcForkResetWorkRequired(best_block['bits']))
+        nBits = CalculateMVFResetWorkRequired(best_block['bits'])
+        reset_bits = int2hex(nBits)
+        reset_diff_expected = bits2difficulty(nBits)
         assert_greater_than(reset_diff_expected, 0)
 
         # Test fork did not trigger prematurely
@@ -110,33 +152,31 @@ class MVF_RETARGET_Test(BitcoinTestFramework):
 
         # Generate fork block
         best_block = self.nodes[0].getblock(self.nodes[0].getbestblockhash(), True)
-        self.nodes[0].setmocktime(best_block['time'] + 600)
+        self.nodes[0].setmocktime(best_block['time'] + STANDARD_BLOCKTIME)
         self.nodes[0].generate(1)
         assert_equal(True,   self.is_fork_triggered_on_node(0))
 
         best_block = self.nodes[0].getblock(self.nodes[0].getbestblockhash(), True)
-        print "Fork triggered successfully (block height %s)" % FORK_BLOCK
+        print "Fork triggered successfully (block height %s)" % best_block['height']
 
         # Test fork difficulty reset
-        #print "expected = %.10f" % reset_diff_expected
-        assert_equal(round(best_block['difficulty'],10),round(reset_diff_expected,10))
+        #print "expected = %.10f actual = %.10f" % (reset_diff_expected,best_block['difficulty'])
+        assert_equal(best_block['bits'],reset_bits)
         #assert_equal(best_block['bits'], "207eeeee") # fixed reset
         print "Post-fork difficulty reset success: %.10f %s " % (best_block['difficulty'], best_block['bits'])
 
         # use to track how many times the same bits are used in a row
         prev_block = 0
         diffadjinterval = 0
-        next_block_time = 0
+        next_block_time = 300
         count_bits_used = 0
-        prev_block_delta = 0
-        prev_blocks_delta_avg = 0
-        diff_factor = 0
 
         # print column titles
-        print "nBits changed @ Time,Block,Delta(secs),nBits,Used,DiffInterval,Difficulty,NextDifficulty,DiffFactor"
+        print "nBits changed @ Time,Block,Delta(secs),nBits,Used,DiffInterval,Difficulty,NextBits"
 
         # start generating MVF blocks with varying time stamps
-        for n in xrange(HARDFORK_RETARGET_BLOCKS + 2017):
+        oneRetargetBlockAfterMVFRetargetPeriod = HARDFORK_RETARGET_BLOCKS+ORIGINAL_DIFFADJINTERVAL+1
+        for n in xrange(oneRetargetBlockAfterMVFRetargetPeriod):
             best_block = self.nodes[0].getblock(self.nodes[0].getbestblockhash(), True)
             prev_block = self.nodes[0].getblock(best_block['previousblockhash'], True)
 
@@ -146,37 +186,49 @@ class MVF_RETARGET_Test(BitcoinTestFramework):
             else:
                 # when the bits change then output the retargeting metrics
                 # for the previous group of bits
-                prev_blocks_delta_avg = decimal.Decimal(prev_block_delta) / count_bits_used
-                diff_factor = 600 / decimal.Decimal(prev_blocks_delta_avg)
-                best_diff_expected = prev_block['difficulty'] * diff_factor
+                first_block = self.nodes[0].getblock(self.nodes[0].getblockhash(prev_block['height'] - diffadjinterval))
+                actualBlockTimeSecs = prev_block['time'] - first_block['time']
+                avgBlockTimeSecs = actualBlockTimeSecs / count_bits_used
 
-                print "%s,%d,%d,%s,%d,%d,%.8f,%.8f,%.4f " %(
+                if n > HARDFORK_RETARGET_BLOCKS :
+                    # returns to standard targetting
+                    nextBits = "standard"
+                    #best_diff_expected = ""
+                    nBits = 0
+                else:
+                    # during MVF retarget period test retarget difficulty function
+                    nBits = CalculateMVFNextWorkRequired(prev_block['bits'], actualBlockTimeSecs, diffadjinterval)
+                    nextBits = int2hex(nBits)
+                    #best_diff_expected = bits2difficulty(nBits)
+                    #print "%s %.10f" % (int2hex(nextBits), best_diff_expected)
+
+                    # Test difficulty
+                    assert_equal(best_block['bits'], nextBits)
+
+                print "%s,%d,%d,%s,%d,%d,%.10f,%s " %(
                     time.strftime("%Y-%m-%d %H:%M",time.gmtime(prev_block['time'])),
                     prev_block['height'],
-                    prev_blocks_delta_avg,
+                    avgBlockTimeSecs,
                     prev_block['bits'],
                     count_bits_used,
                     diffadjinterval,
                     prev_block['difficulty'],
-                    best_diff_expected,
-                    diff_factor
+                    nextBits
                     )
-
-                # Test processed bits are used within the expected difficulty interval
-                # except when the bits is at the bits limit: 207fffff
-                if int("0x%s"%prev_block['bits'],0) <> POW_LIMIT :
-                    assert_less_than_equal(count_bits_used, diffadjinterval)
-
-                # Test difficulty
-                if n <= 500 :
-                    assert_equal(round(best_block['difficulty'],8), round(best_diff_expected,8))
 
                 # reset bits tracking variables
                 count_bits_used = 1
-                prev_block_delta = 0
+                #raw_input()
             #### end if prev_block['bits'] == best_block['bits']
 
-            # setup various block time interval tests
+            # Test processed bits are used within the expected difficulty interval
+            # except when the bits is at the bits limit: 207fffff
+            diffadjinterval = self.nodes[0].getblockchaininfo()['difficultyadjinterval']
+
+            if int("0x%s"%prev_block['bits'],0) <> POW_LIMIT :
+                assert_less_than_equal(count_bits_used, diffadjinterval)
+
+            # Setup various block time interval tests
             if n in range(0,11) :
                 next_block_time = next_block_time + 50
             elif n in range(11,18) :
@@ -199,10 +251,6 @@ class MVF_RETARGET_Test(BitcoinTestFramework):
 
             self.nodes[0].setmocktime(best_block['time'] + next_block_time)
 
-            # track block metrics
-            prev_block_delta = prev_block_delta + (best_block['time'] - prev_block['time'])
-            diffadjinterval = self.nodes[0].getblockchaininfo()['difficultyadjinterval']
-
             # Test the interval matches the interval defined in params.MVFPowTargetTimespan()
             if n in range(0,11) :
                 diff_interval_expected = 1     # 10 mins
@@ -215,17 +263,14 @@ class MVF_RETARGET_Test(BitcoinTestFramework):
             elif n in range(2012,HARDFORK_RETARGET_BLOCKS) :
                 diff_interval_expected = 72    # 12 hours
             else:
-                diff_interval_expected = 2016  # 14 days original
+                diff_interval_expected = ORIGINAL_DIFFADJINTERVAL  # 14 days original
 
-            #print "%d %d" % (diff_interval_expected, diffadjinterval)
-            #if diff_interval_expected <> diffadjinterval : raw_input()
             assert_equal(diff_interval_expected, diffadjinterval)
 
             # print info for every block
             #print "%s :: %s :: %d :: %s :: %d" %(
                 #best_block['height'],
                 #time.strftime("%H:%M",time.gmtime(best_block['time'])),
-                #decimal.Decimal(prev_block_delta) / count_bits_used,
                 #best_block['bits'],
                 #count_bits_used)
 

--- a/qa/rpc-tests/mvf-bu-retarget.py
+++ b/qa/rpc-tests/mvf-bu-retarget.py
@@ -168,6 +168,8 @@ class MVF_RETARGET_Test(BitcoinTestFramework):
         # use to track how many times the same bits are used in a row
         prev_block = 0
         diffadjinterval = 0
+        # the first nexttimeblock test phase is cyclical increases of 50 seconds starting from here
+        # if the starting number is too low it may cause timeout errors too often
         next_block_time = 300
         count_bits_used = 0
 

--- a/qa/rpc-tests/mvf-bu-retarget.py
+++ b/qa/rpc-tests/mvf-bu-retarget.py
@@ -36,7 +36,7 @@ def CalcForkResetWorkRequired(bits):
     nTargetTimespan = nActualTimespan / nDropFactor
 
     # compare with debug.log
-    print "nTargetTimespan %d nActualTimespan=%d" % (nTargetTimespan,nActualTimespan)
+    #print "nTargetTimespan=%d nActualTimespan=%d" % (nTargetTimespan,nActualTimespan)
 
     bnOld = bits2target_int(hex2bin(bits))     # SetCompact
     bnNew1 = bnOld / nTargetTimespan
@@ -132,15 +132,13 @@ class MVF_RETARGET_Test(BitcoinTestFramework):
         prev_blocks_delta_avg = 0
         diff_factor = 0
 
+        # print column titles
+        print "nBits changed @ Time,Block,Delta(secs),nBits,Used,DiffInterval,Difficulty,NextDifficulty,DiffFactor"
+
         # start generating MVF blocks with varying time stamps
         for n in xrange(HARDFORK_RETARGET_BLOCKS + 2017):
             best_block = self.nodes[0].getblock(self.nodes[0].getbestblockhash(), True)
             prev_block = self.nodes[0].getblock(best_block['previousblockhash'], True)
-
-            if best_block['height'] == FORK_BLOCK + 1 :
-                # print column titles
-                print "nBits changed @ Time,Block,Delta(secs),nBits,Used,DiffInterval,Difficulty,NextDifficulty,DiffFactor"
-            # end if best_block['height'] == FORK_BLOCK + 1
 
             # track bits used
             if prev_block['bits'] == best_block['bits'] or best_block['height'] == FORK_BLOCK:
@@ -214,7 +212,7 @@ class MVF_RETARGET_Test(BitcoinTestFramework):
                 diff_interval_expected = 6     # 1 hour
             elif n in range(102,2012) :
                 diff_interval_expected = 18    # 3 hours
-            elif n in range(2012,HARDFORK_RETARGET_BLOCKS+1) :
+            elif n in range(2012,HARDFORK_RETARGET_BLOCKS) :
                 diff_interval_expected = 72    # 12 hours
             else:
                 diff_interval_expected = 2016  # 14 days original

--- a/qa/rpc-tests/test_framework/arith.py
+++ b/qa/rpc-tests/test_framework/arith.py
@@ -1,0 +1,373 @@
+# This file was copied from Slush's stratum-mining project
+# with some modifications
+
+
+'''Various helper methods. It probably needs some cleanup.'''
+
+import struct
+import StringIO
+import binascii
+from hashlib import sha256
+
+def to_hex(s):
+    assert type(s) ==  str # fixme: handle other types
+    assert len(s) == 32
+    return binascii.hexlify(s[::-1])
+
+def deser_varint(f):
+    nit = struct.unpack("<B", f.read(1))[0]
+    if nit == 253:
+        nit = struct.unpack("<H", f.read(2))[0]
+    elif nit == 254:
+        nit = struct.unpack("<I", f.read(4))[0]
+    elif nit == 255:
+        nit = struct.unpack("<Q", f.read(8))[0]
+    return nit
+
+def ser_varint(i):
+    if i < 253:
+        return chr(i)
+    elif i < 0x10000:
+        return chr(253) + struct.pack("<H", i)
+    elif i < 0x100000000L:
+        return chr(254) + struct.pack("<I", i)
+    return chr(255) + struct.pack("<Q", i)
+
+def deser_string(f):
+    nit = struct.unpack("<B", f.read(1))[0]
+    if nit == 253:
+        nit = struct.unpack("<H", f.read(2))[0]
+    elif nit == 254:
+        nit = struct.unpack("<I", f.read(4))[0]
+    elif nit == 255:
+        nit = struct.unpack("<Q", f.read(8))[0]
+    return f.read(nit)
+
+def ser_string(s):
+    if len(s) < 253:
+        return chr(len(s)) + s
+    elif len(s) < 0x10000:
+        return chr(253) + struct.pack("<H", len(s)) + s
+    elif len(s) < 0x100000000L:
+        return chr(254) + struct.pack("<I", len(s)) + s
+    return chr(255) + struct.pack("<Q", len(s)) + s
+
+def deser_uint256(f):
+    r = 0L
+    for i in xrange(8):
+        t = struct.unpack("<I", f.read(4))[0]
+        r += t << (i * 32)
+    return r
+
+def ser_uint256(u):
+    rs = ""
+    for i in xrange(8):
+        rs += struct.pack("<I", u & 0xFFFFFFFFL)
+        u >>= 32
+    return rs
+
+def uint256_from_str(s):
+    r = 0L
+    t = struct.unpack("<IIIIIIII", s[:32])
+    for i in xrange(8):
+        r += t[i] << (i * 32)
+    return r
+
+def uint256_from_str_be(s):
+    r = 0L
+    t = struct.unpack(">IIIIIIII", s[:32])
+    for i in xrange(8):
+        r += t[i] << (i * 32)
+    return r
+
+def uint256_from_compact(c):
+    nbytes = (c >> 24) & 0xFF
+    v = (c & 0xFFFFFFL) << (8 * (nbytes - 3))
+    return v
+
+def deser_vector(f, c):
+    nit = struct.unpack("<B", f.read(1))[0]
+    if nit == 253:
+        nit = struct.unpack("<H", f.read(2))[0]
+    elif nit == 254:
+        nit = struct.unpack("<I", f.read(4))[0]
+    elif nit == 255:
+        nit = struct.unpack("<Q", f.read(8))[0]
+    r = []
+    for i in xrange(nit):
+        t = c()
+        t.deserialize(f)
+        r.append(t)
+    return r
+
+def ser_vector(l):
+    r = ""
+    if len(l) < 253:
+        r = chr(len(l))
+    elif len(l) < 0x10000:
+        r = chr(253) + struct.pack("<H", len(l))
+    elif len(l) < 0x100000000L:
+        r = chr(254) + struct.pack("<I", len(l))
+    else:
+        r = chr(255) + struct.pack("<Q", len(l))
+    for i in l:
+        r += i.serialize()
+    return r
+
+def deser_uint256_vector(f):
+    nit = struct.unpack("<B", f.read(1))[0]
+    if nit == 253:
+        nit = struct.unpack("<H", f.read(2))[0]
+    elif nit == 254:
+        nit = struct.unpack("<I", f.read(4))[0]
+    elif nit == 255:
+        nit = struct.unpack("<Q", f.read(8))[0]
+    r = []
+    for i in xrange(nit):
+        t = deser_uint256(f)
+        r.append(t)
+    return r
+
+def ser_uint256_vector(l):
+    r = ""
+    if len(l) < 253:
+        r = chr(len(l))
+    elif len(l) < 0x10000:
+        r = chr(253) + struct.pack("<H", len(l))
+    elif len(l) < 0x100000000L:
+        r = chr(254) + struct.pack("<I", len(l))
+    else:
+        r = chr(255) + struct.pack("<Q", len(l))
+    for i in l:
+        r += ser_uint256(i)
+    return r
+
+__b58chars = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+__b58base = len(__b58chars)
+
+def b58decode(v, length):
+    """ decode v into a string of len bytes
+    """
+    long_value = 0L
+    for (i, c) in enumerate(v[::-1]):
+        long_value += __b58chars.find(c) * (__b58base**i)
+
+    result = ''
+    while long_value >= 256:
+        div, mod = divmod(long_value, 256)
+        result = chr(mod) + result
+        long_value = div
+    result = chr(long_value) + result
+
+    nPad = 0
+    for c in v:
+        if c == __b58chars[0]: nPad += 1
+        else: break
+
+    result = chr(0)*nPad + result
+    if length is not None and len(result) != length:
+        return None
+
+    return result
+
+def reverse_hash(h):
+    # This only revert byte order, nothing more
+    if len(h) != 64:
+        raise Exception('hash must have 64 hexa chars')
+
+    return ''.join([ h[56-i:64-i] for i in range(0, 64, 8) ])
+
+def doublesha(b):
+    return sha256(sha256(b).digest()).digest()
+
+def bits_to_target(bits):
+    return struct.unpack('<L', bits[:3] + b'\0')[0] * 2**(8*(int(bits[3], 16) - 3))
+
+def address_to_pubkeyhash(addr):
+    try:
+        addr = b58decode(addr, 25)
+    except:
+        return None
+
+    if addr is None:
+        return None
+
+    ver = addr[0]
+    cksumA = addr[-4:]
+    cksumB = doublesha(addr[:-4])[:4]
+
+    if cksumA != cksumB:
+        return None
+
+    return (ver, addr[1:-4])
+
+def ser_uint256_be(u):
+    '''ser_uint256 to big endian'''
+    rs = ""
+    for i in xrange(8):
+        rs += struct.pack(">I", u & 0xFFFFFFFFL)
+        u >>= 32
+    return rs
+
+def deser_uint256_be(f):
+    r = 0L
+    for i in xrange(8):
+        t = struct.unpack(">I", f.read(4))[0]
+        r += t << (i * 32)
+    return r
+
+def ser_number(n):
+    # For encoding nHeight into coinbase
+    s = bytearray(b'\1')
+    while n > 127:
+        s[0] += 1
+        s.append(n % 256)
+        n //= 256
+    s.append(n)
+    return bytes(s)
+
+def script_to_address(addr):
+    d = address_to_pubkeyhash(addr)
+    if not d:
+        raise ValueError('invalid address')
+    (ver, pubkeyhash) = d
+    return b'\x76\xa9\x14' + pubkeyhash + b'\x88\xac'
+
+
+
+def long_hex(bytes):
+  return bytes.encode('hex_codec')
+
+def short_hex(bytes):
+  t = bytes.encode('hex_codec')
+  if len(t) < 11:
+    return t
+  return t[0:4]+"..."+t[-4:]
+
+#################################################################################
+
+# from http://bitcoin.stackexchange.com/a/30458
+
+def target_int2bits(target):
+    # comprehensive explanation here: bitcoin.stackexchange.com/a/2926/2116
+
+    # get in base 256 as a hex string
+    target_hex = int2hex(target)
+
+    bits = "00" if (hex2int(target_hex[: 2]) > 127) else ""
+    bits += target_hex # append
+    bits = hex2bin(bits)
+    length = int2bin(len(bits), 1)
+
+    # the bits value could be zero (0x00) so make sure it is at least 3 bytes
+    bits += hex2bin("0000")
+
+    # the bits value could be bigger than 3 bytes, so cut it down to size
+    bits = bits[: 3]
+
+    return length + bits
+
+def bits2target_int(bits_bytes):
+    exp = bin2int(bits_bytes[: 1]) # exponent is the first byte
+    mult = bin2int(bits_bytes[1:]) # multiplier is all but the first byte
+    return mult * (2 ** (8 * (exp - 3)))
+
+def int2hex(intval):
+    hex_str = hex(intval)[2:]
+    if hex_str[-1] == "L":
+        hex_str = hex_str[: -1]
+    if len(hex_str) % 2:
+        hex_str = "0" + hex_str
+    return hex_str
+
+def hex2int(hex_str):
+    return int(hex_str, 16)
+
+def hex2bin(hex_str):
+    return binascii.a2b_hex(hex_str)
+
+def int2bin(val, pad_length = False):
+    hexval = int2hex(val)
+    if pad_length: # specified in bytes
+        hexval = hexval.zfill(2 * pad_length)
+    return hex2bin(hexval)
+
+def bin2hex(binary):
+    # convert raw binary data to a hex string. also accepts ascii chars (0 - 255)
+    return binascii.b2a_hex(binary)
+
+#>>> bits_bytes = target_int2bits(22791193517536179595645637622052884930882401463536451358196587084939)
+#>>> bin2hex(bits_bytes)
+#'1d00d86a'
+#>>> # this ^^ is the value in blockexplorer.com in brackets.
+#>>> # display the "bits" as an integer:
+#>>> bits2target_int(bits_bytes)
+#22791060871177364286867400663010583169263383106957897897309909286912L
+#>>> # this ^^ is the value at the end of your answer.
+
+#################################################################################
+
+
+# own code:
+
+# Bitcoin difficulty 1 target - used for computing difficulty
+MAX_DIFF_1  = 0x00000000FFFF0000000000000000000000000000000000000000000000000000
+
+# not really using POOL_DIFF_1, I believe
+POOL_DIFF_1 = 0x00000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+
+def compute_difficulty_from_uint256(target):
+    # ref. https://en.bitcoin.it/wiki/Difficulty#What_is_the_formula_for_difficulty.3F
+    return MAX_DIFF_1 / float(target)
+
+def compute_target_from_difficulty(difficulty):
+    return int(MAX_DIFF_1 / float(difficulty))
+
+#def bits2difficulty(bits):
+#    target = uint256_from_compact(bits)
+#    return compute_difficulty_from_uint256(target)
+
+def bits2difficulty(bits):
+    # Floating point number that is a multiple of the minimum difficulty,
+    # minimum difficulty = 1.0.
+
+    nShift = (bits >> 24) & 0xff
+
+    dDiff = float(0x0000ffff) / float(bits & 0x00ffffff)
+
+    while nShift < 29:
+        dDiff *= 256.0
+        nShift += 1
+    while nShift > 29:
+        dDiff /= 256.0
+        nShift -= 1
+
+    # not supposed to return diff < 1.0 
+    # but it seems this is possible indeed, despite the above comment in CPP function
+    #assert dDiff >= 1.0, "diff M 1.0: %s" % dDiff
+
+    return dDiff
+
+
+def diff2bits(diff, maxdiff=MAX_DIFF_1):
+    target = int(maxdiff / float(diff))
+    return target_int2bits(target)
+
+def bin2int(bytestring):
+    result = 0
+    remainder = bytestring
+    while len(remainder) > 0:
+        if len(remainder) == 1:
+            first_byte = int(ord(remainder[0]))
+            remainder = ''
+        else:
+            first_byte, remainder = int(ord(remainder[0])), remainder[1:] 
+        result = (result << 8) + first_byte
+    return result
+
+def diffstr2target(hexstr):
+    """ returns the target for a difficulty in compact hex (bdiff)
+        such as is output by command line clients"""
+    int_diff = int('0x' + hexstr, 16)
+    return int_diff
+

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -92,7 +92,7 @@ struct Params {
         else
             return false;
     }
-
+    int64_t DifficultyAdjustmentInterval() const { return nPowTargetTimespan / nPowTargetSpacing; }
     int64_t DifficultyAdjustmentInterval(int Height) const
     {
         // MVF-BU:

--- a/src/mvf-bu.cpp
+++ b/src/mvf-bu.cpp
@@ -82,7 +82,7 @@ void ForkSetup(const CChainParams& chainparams)
     FinalActivateForkHeight = GetArg("-forkheight", minForkHeightForNetwork);
 
     // shut down immediately if specified fork height is invalid
-    if (FinalActivateForkHeight < minForkHeightForNetwork)
+    if (FinalActivateForkHeight <= 0)
     {
         LogPrintf("MVF: Error: specified fork height (%d) is less than minimum for '%s' network (%d)\n", FinalActivateForkHeight, activeNetworkID, minForkHeightForNetwork);
         StartShutdown();
@@ -221,3 +221,6 @@ void DeactivateFork(void)
     LogPrintf("%s: MVF: disabling isMVFHardForkActive\n", __func__);
     isMVFHardForkActive = false;
 }
+
+
+

--- a/src/mvf-bu.h
+++ b/src/mvf-bu.h
@@ -25,7 +25,7 @@ enum {
 HARDFORK_HEIGHT_MAINNET =  666666,   // operational network trigger height
 HARDFORK_HEIGHT_TESTNET = 9999999,   // public test network trigger height
 HARDFORK_HEIGHT_NOLNET  = 8888888,   // BU public no-limit test network  trigger height
-HARDFORK_HEIGHT_REGTEST =     100,   // regression test network (local)  trigger height
+HARDFORK_HEIGHT_REGTEST = 9999999,   // regression test network (local)  trigger height
 
 // MVHF-BU-DES-DIAD-3 / MVHF-BU-DES-DIAD-4
 // period (in blocks) from fork activation until retargeting returns to normal

--- a/src/mvf-bu.h
+++ b/src/mvf-bu.h
@@ -29,7 +29,7 @@ HARDFORK_HEIGHT_REGTEST =     100,   // regression test network (local)  trigger
 
 // MVHF-BU-DES-DIAD-3 / MVHF-BU-DES-DIAD-4
 // period (in blocks) from fork activation until retargeting returns to normal
-HARDFORK_RETARGET_BLOCKS = 25920,    // 180*144 blocks
+HARDFORK_RETARGET_BLOCKS = 90*144,    // MVF-BU TODO: Revert after testing to 180*144 (25920) blocks
 
 // MVHF-BU-DES-NSEP-1 - network separation parameter defaults
 // MVF-BU TODO: re-check that these port values could be used

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -94,6 +94,7 @@ unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nF
 }
 
 // MVF-BU begin: difficulty functions
+// TODO: Move these functions into mvf-bu.cpp
 unsigned int GetMVFNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params& params)
 {
     unsigned int nProofOfWorkLimit = UintToArith256(params.powLimit).GetCompact();

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -165,7 +165,7 @@ unsigned int CalculateMVFNextWorkRequired(const CBlockIndex* pindexLast, int64_t
          return bnPowLimit.GetCompact();
     }
     // MVF-BU end
-    LogPrintf("  mvf: nActualTimespan = %d  before bounds\n", nActualTimespan);
+    LogPrintf("  MVF: nActualTimespan = %d  before bounds\n", nActualTimespan);
 
     // MVF-BU begin
     // target time span while within the re-target period
@@ -226,6 +226,7 @@ unsigned int CalculateMVFResetWorkRequired(const CBlockIndex* pindexLast, int64_
 
     arith_uint256 bnNew, bnNew1, bnNew2, bnOld;
 
+    // TODO : Determine best reset formula
     // drop difficulty via factor
     int nDropFactor = 4;
     // use same formula as standard

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -15,33 +15,115 @@
 
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params& params)
 {
+    // MVF-BU begin difficulty re-targeting
+    if (params.MVFisWithinRetargetPeriod(pindexLast->nHeight+1))
+        return GetMVFNextWorkRequired(pindexLast, pblock, params);
+    // MVF-BU end
+
     unsigned int nProofOfWorkLimit = UintToArith256(params.powLimit).GetCompact();
 
     // Genesis block
     if (pindexLast == NULL)
         return nProofOfWorkLimit;
 
-    // MVF-BU begin difficulty re-targeting reset (MVHF-BU-DES-DIAD-2)
-    if (pindexLast->nHeight+1 == FinalActivateForkHeight)
+    // Only change once per difficulty adjustment interval
+    if ((pindexLast->nHeight+1) % params.DifficultyAdjustmentInterval(pindexLast->nHeight) != 0)
     {
-        int nHeightFirst = pindexLast->nHeight - params.DifficultyAdjustmentInterval(pindexLast->nHeight);
-        assert(nHeightFirst >= 0);
-        const CBlockIndex* pindexFirst = pindexLast->GetAncestor(nHeightFirst);
-        assert(pindexFirst);
+        // MVF-BU: added force-retarget parameter to enable adjusting difficulty for regtest tests
+        if (params.fPowAllowMinDifficultyBlocks && !GetBoolArg("-force-retarget", false))
+        {
+            // Special difficulty rule for testnet:
+            // If the new block's timestamp is more than 2* 10 minutes
+            // then allow mining of a min-difficulty block.
+            if (pblock->GetBlockTime() > pindexLast->GetBlockTime() + params.nPowTargetSpacing*2)
+                return nProofOfWorkLimit;
+            else
+            {
+                // Return the last non-special-min-difficulty-rules-block
+                const CBlockIndex* pindex = pindexLast;
+                while (pindex->pprev && pindex->nHeight % params.DifficultyAdjustmentInterval(pindex->nHeight) != 0 && pindex->nBits == nProofOfWorkLimit)
+                    pindex = pindex->pprev;
+                return pindex->nBits;
+            }
+        }
+        return pindexLast->nBits;
+    }
 
-        return CalcForkResetWorkRequired(pindexLast, pindexFirst->GetBlockTime(), params);
+    // Go back by what we want to be 14 days worth of blocks
+    int nHeightFirst = pindexLast->nHeight - (params.DifficultyAdjustmentInterval(pindexLast->nHeight)-1);
+    assert(nHeightFirst >= 0);
+    const CBlockIndex* pindexFirst = pindexLast->GetAncestor(nHeightFirst);
+    assert(pindexFirst);
+
+    return CalculateNextWorkRequired(pindexLast, pindexFirst->GetBlockTime(), params);
+}
+
+unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params& params)
+{
+    // MVF-BU: added force-retarget parameter to enable adjusting difficulty for regtest tests
+    if (params.fPowNoRetargeting && !GetBoolArg("-force-retarget", false))
+        return pindexLast->nBits;
+
+    // Limit adjustment step
+    int64_t nActualTimespan = pindexLast->GetBlockTime() - nFirstBlockTime;
+    LogPrintf("  nActualTimespan = %d  before bounds\n", nActualTimespan);
+    if (nActualTimespan < params.nPowTargetTimespan/4)
+        nActualTimespan = params.nPowTargetTimespan/4;
+    if (nActualTimespan > params.nPowTargetTimespan*4)
+        nActualTimespan = params.nPowTargetTimespan*4;
+
+    // Retarget
+    const arith_uint256 bnPowLimit = UintToArith256(params.powLimit);
+    arith_uint256 bnNew;
+    arith_uint256 bnOld;
+    bnNew.SetCompact(pindexLast->nBits);
+    bnOld = bnNew;
+    bnNew *= nActualTimespan;
+    bnNew /= params.nPowTargetTimespan;
+
+    if (bnNew > bnPowLimit)
+        bnNew = bnPowLimit;
+
+    /// debug print
+    LogPrintf("GetNextWorkRequired RETARGET\n");
+    LogPrintf("params.nPowTargetTimespan = %d    nActualTimespan = %d\n", params.nPowTargetTimespan, nActualTimespan);
+    LogPrintf("Before: %08x  %s\n", pindexLast->nBits, bnOld.ToString());
+    LogPrintf("After:  %08x  %s\n", bnNew.GetCompact(), bnNew.ToString());
+
+    return bnNew.GetCompact();
+}
+
+// MVF-BU begin: difficulty functions
+unsigned int GetMVFNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params& params)
+{
+    unsigned int nProofOfWorkLimit = UintToArith256(params.powLimit).GetCompact();
+
+    LogPrintf("MVF NEXT WORK DifficultyAdjInterval = %d , TargetTimeSpan = %d \n",
+            params.DifficultyAdjustmentInterval(pindexLast->nHeight),
+            params.MVFPowTargetTimespan(pindexLast->nHeight));
+
+    // Genesis block
+    if (pindexLast == NULL) return nProofOfWorkLimit;
+
+    int nHeightFirst = pindexLast->nHeight - params.DifficultyAdjustmentInterval(pindexLast->nHeight);
+    if (nHeightFirst < 0) nHeightFirst = 0;
+    const CBlockIndex* pindexFirst = pindexLast->GetAncestor(nHeightFirst);
+    assert(pindexFirst);
+
+    if (pindexLast->nHeight == FinalActivateForkHeight - 1)
+    {
+        // MVF-BU difficulty re-targeting reset (MVHF-BU-DES-DIAD-2)
+        return CalculateMVFResetWorkRequired(pindexLast, pindexFirst->GetBlockTime(), params);
     }
     else
     {
-        LogPrintf("MVF DEBUG DifficultyAdjInterval = %d , TargetTimeSpan = %d \n", params.DifficultyAdjustmentInterval(pindexLast->nHeight), params.MVFPowTargetTimespan(pindexLast->nHeight));
-        // MVF-BU end
-
         // Only change once per difficulty adjustment interval
         if ((pindexLast->nHeight+1) % params.DifficultyAdjustmentInterval(pindexLast->nHeight) != 0)  // MVF-BU: use height-dependent interval
         {
             // MVF-BU: added force parameter to enable adjusting difficulty for regtest tests
             if (params.fPowAllowMinDifficultyBlocks && !GetBoolArg("-force-retarget", false))
             {
+                // TODO: CAUTION THIS CODE IS OUTSIDE REGTEST FRAMEWORK
                 // Special difficulty rule for testnet:
                 // If the new block's timestamp is more than 2* 10 minutes
                 // then allow mining of a min-difficulty block.
@@ -52,30 +134,20 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
                     // Return the last non-special-min-difficulty-rules-block
                     const CBlockIndex* pindex = pindexLast;
                     // MVF-BU: use height-dependent interval
-                    while (pindex->pprev && pindex->nHeight % params.DifficultyAdjustmentInterval(pindexLast->nHeight) != 0 && pindex->nBits == nProofOfWorkLimit)
+                    while (pindex->pprev && pindex->nHeight % params.DifficultyAdjustmentInterval(pindex->nHeight) != 0 && pindex->nBits == nProofOfWorkLimit)
                         pindex = pindex->pprev;
                     return pindex->nBits;
                 }
             }
             return pindexLast->nBits;
         }
+        LogPrintf("MVF RETARGET");
+        return CalculateMVFNextWorkRequired(pindexLast, pindexFirst->GetBlockTime(), params);
 
-        // MVF-BU begin
-        // Go back by what we want to be 14 days worth of blocks (normally)
-        int nHeightFirst = pindexLast->nHeight - (params.DifficultyAdjustmentInterval(pindexLast->nHeight)-1);
-        // while within the retarget period override the original formula to handle a dynamic time span
-        if (params.MVFisWithinRetargetPeriod(pindexLast->nHeight))
-            nHeightFirst = pindexLast->nHeight - params.DifficultyAdjustmentInterval(pindexLast->nHeight);
-        // MVF-BU end
-        assert(nHeightFirst >= 0);
-        const CBlockIndex* pindexFirst = pindexLast->GetAncestor(nHeightFirst);
-        assert(pindexFirst);
-
-        return CalculateNextWorkRequired(pindexLast, pindexFirst->GetBlockTime(), params);
     } // end fork reset
 }
 
-unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params& params)
+unsigned int CalculateMVFNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params& params)
 {
     bool force_retarget=GetBoolArg("-force-retarget", false);  // MVF-BU added for retargeting tests on regtestnet (MVHF-BU-DES-DIAD-6)
     const arith_uint256 bnPowLimit = UintToArith256(params.powLimit); // MVF-BU moved here
@@ -93,7 +165,7 @@ unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nF
          return bnPowLimit.GetCompact();
     }
     // MVF-BU end
-    LogPrintf("  nActualTimespan = %d  before bounds\n", nActualTimespan);
+    LogPrintf("  mvf: nActualTimespan = %d  before bounds\n", nActualTimespan);
 
     // MVF-BU begin
     // target time span while within the re-target period
@@ -147,7 +219,8 @@ unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nF
     return bnNew.GetCompact();
 }
 
-unsigned int CalcForkResetWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params& params)
+/** Perform the fork difficulty reset */
+unsigned int CalculateMVFResetWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params& params)
 {
     const arith_uint256 bnPowLimit = UintToArith256(params.powLimit); // MVF-BU moved here
 
@@ -169,7 +242,7 @@ unsigned int CalcForkResetWorkRequired(const CBlockIndex* pindexLast, int64_t nF
         bnNew = bnPowLimit;
     else bnNew = bnNew2;
 
-    // fix difficulty to constant near the limit
+    // ignore formula above and override with fixed difficulty
     //bnNew.SetCompact(0x207eeeee);
 
     /// debug print
@@ -179,6 +252,7 @@ unsigned int CalcForkResetWorkRequired(const CBlockIndex* pindexLast, int64_t nF
     LogPrintf("After MVF FORK BLOCK DIFFICULTY RESET  %08x  %s\n", bnNew.GetCompact(),bnNew.ToString());
     return bnNew.GetCompact();
 }
+// MVF-BU end: difficulty functions
 
 bool CheckProofOfWork(uint256 hash, unsigned int nBits, const Consensus::Params& params)
 {

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -27,7 +27,7 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
         return nProofOfWorkLimit;
 
     // Only change once per difficulty adjustment interval
-    if ((pindexLast->nHeight+1) % params.DifficultyAdjustmentInterval(pindexLast->nHeight) != 0)
+    if ((pindexLast->nHeight+1) % params.DifficultyAdjustmentInterval() != 0)
     {
         // MVF-BU: added force-retarget parameter to enable adjusting difficulty for regtest tests
         if (params.fPowAllowMinDifficultyBlocks && !GetBoolArg("-force-retarget", false))
@@ -41,7 +41,7 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
             {
                 // Return the last non-special-min-difficulty-rules-block
                 const CBlockIndex* pindex = pindexLast;
-                while (pindex->pprev && pindex->nHeight % params.DifficultyAdjustmentInterval(pindex->nHeight) != 0 && pindex->nBits == nProofOfWorkLimit)
+                while (pindex->pprev && pindex->nHeight % params.DifficultyAdjustmentInterval() != 0 && pindex->nBits == nProofOfWorkLimit)
                     pindex = pindex->pprev;
                 return pindex->nBits;
             }
@@ -50,7 +50,7 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
     }
 
     // Go back by what we want to be 14 days worth of blocks
-    int nHeightFirst = pindexLast->nHeight - (params.DifficultyAdjustmentInterval(pindexLast->nHeight)-1);
+    int nHeightFirst = pindexLast->nHeight - (params.DifficultyAdjustmentInterval()-1);
     assert(nHeightFirst >= 0);
     const CBlockIndex* pindexFirst = pindexLast->GetAncestor(nHeightFirst);
     assert(pindexFirst);

--- a/src/pow.h
+++ b/src/pow.h
@@ -18,6 +18,7 @@ class arith_uint256;
 
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params&);
 unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params&);
+unsigned int CalcForkResetWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params&);
 
 /** Check whether a block hash satisfies the proof-of-work requirement specified by nBits */
 bool CheckProofOfWork(uint256 hash, unsigned int nBits, const Consensus::Params&);

--- a/src/pow.h
+++ b/src/pow.h
@@ -19,6 +19,7 @@ class arith_uint256;
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params&);
 unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params&);
 // MVF-BU begin
+// TODO: Move these functions into mvf-bu.h
 unsigned int GetMVFNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params&);
 unsigned int CalculateMVFNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params&);
 unsigned int CalculateMVFResetWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params&);

--- a/src/pow.h
+++ b/src/pow.h
@@ -18,7 +18,11 @@ class arith_uint256;
 
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params&);
 unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params&);
-unsigned int CalcForkResetWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params&);
+// MVF-BU begin
+unsigned int GetMVFNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params&);
+unsigned int CalculateMVFNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params&);
+unsigned int CalculateMVFResetWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params&);
+// MVF-BU end
 
 /** Check whether a block hash satisfies the proof-of-work requirement specified by nBits */
 bool CheckProofOfWork(uint256 hash, unsigned int nBits, const Consensus::Params&);

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -55,11 +55,7 @@ BOOST_AUTO_TEST_CASE(get_next_work_lower_limit_actual)
     pindexLast.nHeight = 68543;
     pindexLast.nTime = 1279297671;  // Block #68543
     pindexLast.nBits = 0x1c05a3f4;
-    // MVF-BU begin
-    // due to reversal of multiply-divide calculation in CalculateNextWorkRequired,
-    // this rounds slightly differently (change in last digit)
-    BOOST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime, params), 0x1c0168fc);
-    // MVF-BU end
+    BOOST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime, params), 0x1c0168fd);
 }
 
 /* Test the constraint on the upper bound for actual time taken */
@@ -111,7 +107,7 @@ BOOST_AUTO_TEST_CASE(MVFCheckOverflowCalculation_test)
     const Consensus::Params& params = Params().GetConsensus();
     const arith_uint256 bnPowLimit = UintToArith256(params.powLimit); // MVF-BU moved here
 
-
+    // test scenario post fork
     FinalActivateForkHeight = 2016;
 
     int64_t nLastRetargetTime = 7;  // Force an excessive retarget time to trigger overflow
@@ -124,7 +120,7 @@ BOOST_AUTO_TEST_CASE(MVFCheckOverflowCalculation_test)
     // need to set -force-retarget, otherwise cannot test overflow
     // because it would never reach the computation
     SoftSetBoolArg("-force-retarget", true);
-    BOOST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime, params), bnPowLimit.GetCompact());
+    BOOST_CHECK_EQUAL(CalculateMVFNextWorkRequired(&pindexLast, nLastRetargetTime, params), bnPowLimit.GetCompact());
 }
 // MVF-BU end
 


### PR DESCRIPTION
Added CalcForkResetWorkRequired() to pow.cpp and python clone for testing within mvf-by-retarget.py. The fork reset work formula uses a factor of 4 to drop the target from previous difficulty. It does this by keeping the same nActualTimespan formula but modifying the nTargetTimespan value :  nTargetTimespan = nActualTimespan / nDropFactor. The standard retarget calculations follow with overflow/limit checks.