### PR TITLE
Req8/retarget

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -125,7 +125,7 @@ testScriptsExt = [ RpcTest(t) for t in [
     Disabled('bip68-sequence', "TODO"),
     'bipdersig-p2p',
     'bipdersig',
-    #'getblocktemplate_longpoll', # commented out because its failing on core 0.12 src
+    'getblocktemplate_longpoll',
     'getblocktemplate_proposals',
     'txn_doublespend',
     'txn_clone --mineblock',

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -125,7 +125,7 @@ testScriptsExt = [ RpcTest(t) for t in [
     Disabled('bip68-sequence', "TODO"),
     'bipdersig-p2p',
     'bipdersig',
-    'getblocktemplate_longpoll',
+    #'getblocktemplate_longpoll', # commented out because its failing on core 0.12 src
     'getblocktemplate_proposals',
     'txn_doublespend',
     'txn_clone --mineblock',

--- a/qa/rpc-tests/mvf-bu-retarget.py
+++ b/qa/rpc-tests/mvf-bu-retarget.py
@@ -189,7 +189,7 @@ class MVF_RETARGET_Test(BitcoinTestFramework):
             prev_block = self.nodes[0].getblock(best_block['previousblockhash'], True)
 
             # track bits used
-            if (prev_block['bits'] == best_block['bits'] or best_block['height'] == FORK_BLOCK)and n < oneRetargetPeriodAfterMVFRetargetPeriod :
+            if (prev_block['bits'] == best_block['bits'] or best_block['height'] == FORK_BLOCK)and n < oneRetargetPeriodAfterMVFRetargetPeriod -1 :
                 count_bits_used += 1
             else:
                 # when the bits change then output the retargeting metrics

--- a/qa/rpc-tests/mvf-bu-retarget.py
+++ b/qa/rpc-tests/mvf-bu-retarget.py
@@ -33,13 +33,16 @@ def CalculateMVFNextWorkRequired(bits, actualBlockTimeSecs, targetBlockTimeSecs)
     # Target by interval
     nTargetTimespan = targetBlockTimeSecs
 
-    # permit abrupt changes for a few blocks after the fork i.e. when nTargetTimespan is < 30 minutes (MVHF-BU-DES-DIAD-5)
+    # permit 10x retargetchanges for a few blocks after the fork i.e. when nTargetTimespan is < 30 minutes (MVHF-BU-DES-DIAD-5)
     if (nTargetTimespan >= STANDARD_BLOCKTIME * 3) :
-        # prevent abrupt changes to target
-        if (nActualTimespan < nTargetTimespan/4) :
-            nActualTimespan = nTargetTimespan/4
-        if (nActualTimespan > nTargetTimespan*4) :
-            nActualTimespan = nTargetTimespan*4
+        retargetLimit = 4
+    else :
+        retargetLimit = 10
+    # prevent abrupt changes to target
+    if (nActualTimespan < nTargetTimespan/retargetLimit) :
+        nActualTimespan = nTargetTimespan/retargetLimit
+    if (nActualTimespan > nTargetTimespan*retargetLimit) :
+        nActualTimespan = nTargetTimespan*retargetLimit
 
     # compare with debug.log
     #print "nTargetTimespan=%d nActualTimespan=%d" % (nTargetTimespan,nActualTimespan)

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -75,7 +75,7 @@ struct Params {
 
             switch (MVFHeight)
             {
-                case    0 ... 7         : return nPowTargetSpacing;          // 10 minutes (abrupt retargeting permitted)
+                case    0 ... 7         : return nPowTargetSpacing;          // 10 minutes
 
                 case    8 ... 46        : return nPowTargetSpacing * 6;      // 1 hour
 

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -105,7 +105,7 @@ unsigned int GetMVFNextWorkRequired(const CBlockIndex* pindexLast, const CBlockH
     // Genesis block
     if (pindexLast == NULL) return nProofOfWorkLimit;
 
-    int nHeightFirst = pindexLast->nHeight - params.DifficultyAdjustmentInterval(pindexLast->nHeight);
+    int nHeightFirst = pindexLast->nHeight - (params.MVFPowTargetTimespan(pindexLast->nHeight) / params.nPowTargetSpacing);
     if (nHeightFirst < 0) nHeightFirst = 0;
     const CBlockIndex* pindexFirst = pindexLast->GetAncestor(nHeightFirst);
     assert(pindexFirst);
@@ -167,13 +167,8 @@ unsigned int CalculateMVFNextWorkRequired(const CBlockIndex* pindexLast, int64_t
     // MVF-BU end
     LogPrintf("  mvf: nActualTimespan = %d  before bounds\n", nActualTimespan);
 
-    // MVF-BU begin
-    // target time span while within the re-target period
-    int64_t nTargetTimespan = params.nPowTargetTimespan; // the original 14 days
-
-    // if in MVF fork recovery period, use faster retarget time span dependent on height (MVHF-BU-DES-DIAD-3)
-    if (params.MVFisWithinRetargetPeriod(pindexLast->nHeight))
-        nTargetTimespan = params.MVFPowTargetTimespan(pindexLast->nHeight);
+    // Since in MVF fork re-target period, use faster retarget time span dependent on height (MVHF-BU-DES-DIAD-3)
+    int64_t nTargetTimespan = params.MVFPowTargetTimespan(pindexLast->nHeight);
 
     // permit abrupt changes for a few blocks after the fork i.e. when nTargetTimespan is < 30 minutes (MVHF-BU-DES-DIAD-5)
     if (nTargetTimespan >= params.nPowTargetSpacing * 3)

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -390,7 +390,8 @@ UniValue getblock(const UniValue& params, bool fHelp)
             "  \"chainwork\" : \"xxxx\",  (string) Expected number of hashes required to produce the chain up to this block (in hex)\n"
             "  \"previousblockhash\" : \"hash\",  (string) The hash of the previous block\n"
             "  \"nextblockhash\" : \"hash\"       (string) The hash of the next block\n"
-            "  \"difficultyadjinterval\" : n,     (numeric) The number of blocks between difficulty adjustment \n"  // MVF-BU (MVHF-BU-DES-DIAD-7)
+            "  \"difficultyadjinterval\" : n,     (numeric) The number of seconds targeted between difficulty adjustment \n"  // MVF-BU (MVHF-BU-DES-DIAD-7)
+            "  \"difficultytimespan\" : n,     (numeric) The number of seconds to aggregate when retargeting difficulty \n"  // MVF-BU (MVHF-BU-DES-DIAD-7)
             "}\n"
             "\nResult (for verbose=false):\n"
             "\"data\"             (string) A string that is serialized, hex-encoded data for block 'hash'.\n"
@@ -654,6 +655,7 @@ UniValue getblockchaininfo(const UniValue& params, bool fHelp)
             "  \"bestblockhash\": \"...\", (string) the hash of the currently best block\n"
             "  \"difficulty\": xxxxxx,     (numeric) the current difficulty\n"
             "  \"difficultyadjinterval\": xxxxxx,         (numeric) the number of blocks between difficulty adjustments\n"  // MVF-BU
+            "  \"difficultytimespan\": xxxxxx,         (numeric) the number of seconds targeted to aggregate when retargeting difficulty \n"  // MVF-BU
             "  \"mediantime\": xxxxxx,     (numeric) median time for the current best block\n"
             "  \"verificationprogress\": xxxx, (numeric) estimate of verification progress [0..1]\n"
             "  \"chainwork\": \"xxxx\"     (string) total amount of work in active chain, in hexadecimal\n"
@@ -709,6 +711,7 @@ UniValue getblockchaininfo(const UniValue& params, bool fHelp)
     obj.push_back(Pair("softforks",             softforks));
     obj.push_back(Pair("bip9_softforks", bip9_softforks));
     obj.push_back(Pair("difficultyadjinterval", consensusParams.DifficultyAdjustmentInterval(tip->nHeight)));  // MVF-BU (MVHF-BU-DES-DIAD-7)
+    obj.push_back(Pair("difficultytimespan", consensusParams.MVFPowTargetTimespan(tip->nHeight)));  // MVF-BU (MVHF-BU-DES-DIAD-7)
 
     // MVF-BU begin output hardfork description (MVHF-BU-DES-TRIG-9)
     if (!isMVFHardForkActive)


### PR DESCRIPTION
Remove unlimited abrupt retargeting and replaced with a 10x limit.

Separate difficultytimespan and difficultyadjinterval and create new retarget schedules for both.

Add difficultytimespan command to rpcblockchain.cpp.

Update mvf-bu-retarget for testing the new schedules.
 