### PR TITLE
add --randomseed option to test framework, adapt mvf-bu-retarget and excessive tests

### DIFF
--- a/qa/rpc-tests/excessive.py
+++ b/qa/rpc-tests/excessive.py
@@ -130,7 +130,9 @@ class ExcessiveBlockTest (BitcoinTestFramework):
       
 
         print "Random test"
-        random.seed(1)
+        # MVF-BU: removed random.seed(1) as not much point to a constant seed
+        # random seed is initialized by test framework, we print it for reference
+        print "Random seed: %s" % self.randomseed
         for i in range(0,2):
           print "round ", i,
           for n in self.nodes:

--- a/qa/rpc-tests/mvf-bu-retarget.py
+++ b/qa/rpc-tests/mvf-bu-retarget.py
@@ -12,9 +12,6 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 from test_framework.arith import *
 from random import randint
-seed = time.time()
-random.seed(seed)
-print "Random seed: %d " % seed
 
 # period (in blocks) from fork activation until retargeting returns to normal
 # MVF-BU TODO: Revert to 180*144
@@ -115,6 +112,8 @@ def CalculateMVFResetWorkRequired(bits):
 class MVF_RETARGET_Test(BitcoinTestFramework):
 
     def setup_chain(self):
+        # random seed is initialized by the test framework
+        print "Random seed: %d " % self.randomseed
         print("Initializing test directory " + self.options.tmpdir)
         initialize_chain_clean(self.options.tmpdir, 1)
 

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -9,6 +9,8 @@
 # Add python-bitcoinrpc to module search path:
 import os
 import sys
+import time     # MVF-BU added
+import random   # MVF-BU added
 
 import shutil
 import tempfile
@@ -111,8 +113,20 @@ class BitcoinTestFramework(object):
                           help="Print out all RPC calls as they are made")
         parser.add_option("--coveragedir", dest="coveragedir",
                           help="Write tested RPC commands into this directory")
+        # MVF-BU begin added for tests using randomness (e.g. mvf-bu-retarget.py)
+        parser.add_option("--randomseed", dest="randomseed",
+                          help="Set RNG seed for tests that use randomness (ignored otherwise)")
+        # MVF-BU end
         self.add_options(parser)
         (self.options, self.args) = parser.parse_args()
+
+        # MVF-BU begin added for tests using randomness (e.g. mvf-bu-retarget.py)
+        if self.options.randomseed:
+            self.randomseed = int(self.options.randomseed)
+        else:
+            self.randomseed = time.time()
+        random.seed(self.randomseed)
+        # MVF-BU end
 
         if self.options.trace_rpc:
             import logging


### PR DESCRIPTION
This moves the random seed generation into the test framework itself, via a new option
--randomseed=X understood by the BitcoinTestFramework class.

If the option is not specified, a random seed will be initialized based on the current time, just like mvf-bu-retarget did.

Failed tests which use randomness can thus be re-run with the same seed.

mvf-bu-retarget is adapted to just print out the random seed, not generate it itself.

excessive.py is also adapted - it used a fixed seed (1), now we print out the variable random seed