### PR TITLE
add a --nosegwitfork command line option to disable fork-on-SW

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2812,7 +2812,8 @@ void static UpdateTip(CBlockIndex *pindexNew) {
     // MVF-BU TODO: the block height test condition below uses strict equality - check if correct
     // right now we haven't found a test case where >= would be needed, but we need to check if test coverage is inadequate
     if (!isMVFHardForkActive && ((chainActive.Height() == FinalActivateForkHeight)
-                             || VersionBitsTipState(chainParams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT) == THRESHOLD_ACTIVE))
+                             || ( VersionBitsTipState(chainParams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT) == THRESHOLD_ACTIVE
+				  && GetBoolArg("-segwitfork", DEFAULT_TRIGGER_ON_SEGWIT))))
     {
         // MVF-BU TODO: decide on above condition
         // if preparations are only made after block has been accepted, then only FinalActivateForkHeight+1 can be new rules
@@ -4175,8 +4176,9 @@ bool static LoadBlockIndexDB()
 
     // MVF-BU begin
     // check if hardfork needs activating
-    if (!isMVFHardForkActive && (chainActive.Height() >= FinalActivateForkHeight
-                             || VersionBitsTipState(chainparams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT) == THRESHOLD_ACTIVE))
+    if (!isMVFHardForkActive && ((chainActive.Height() >= FinalActivateForkHeight)
+                             || ( VersionBitsTipState(chainparams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT) == THRESHOLD_ACTIVE
+                                  && GetBoolArg("-segwitfork", DEFAULT_TRIGGER_ON_SEGWIT))))
     {
         ActivateFork(chainActive.Height(), false);
     }

--- a/src/mvf-bu.cpp
+++ b/src/mvf-bu.cpp
@@ -100,8 +100,20 @@ void ForkSetup(const CChainParams& chainparams)
         }
     }
 
+    if (GetBoolArg("-segwitfork", DEFAULT_TRIGGER_ON_SEGWIT))
+        LogPrintf("%s: MVF: Segregated Witness trigger is ENABLED\n", __func__);
+    else
+        LogPrintf("%s: MVF: Segregated Witness trigger is DISABLED\n", __func__);
+
     LogPrintf("%s: MVF: active fork height = %d\n", __func__, FinalActivateForkHeight);
+
     LogPrintf("%s: MVF: active fork id = 0x%06x (%d)\n", __func__, FinalForkId, FinalForkId);
+
+    if (GetBoolArg("-force-retarget", DEFAULT_FORCE_RETARGET))
+        LogPrintf("%s: MVF: force-retarget is ENABLED\n", __func__);
+    else
+        LogPrintf("%s: MVF: force-retarget is DISABLED\n", __func__);
+
     LogPrintf("%s: MVF: auto backup block = %d\n", __func__, GetArg("-autobackupblock", FinalActivateForkHeight - 1));
 
     // check if btcfork.conf exists (MVHF-BU-DES-TRIG-10)

--- a/src/mvf-bu.h
+++ b/src/mvf-bu.h
@@ -67,6 +67,16 @@ static const uint256 HARDFORK_POWRESET_MAINNET = uint256S("00007ffffffffffffffff
 // MVHF-BU-DES-TRIG-10 - config file that is written when forking, and used to detect "forked" condition at start
 const char * const BTCFORK_CONF_FILENAME = "btcfork.conf";
 
+// MVHF-BU-DES-DIAD-? -force-retarget option determines  whether to actively retarget on regtest after fork happens
+// (not all tests need that, so the POW/difficulty fork related ones that do specifically invoke this option)
+const bool DEFAULT_FORCE_RETARGET = false;
+
+// default value for -nosegwitfork option to disable the fork trigger on SegWit activation
+// caution: -noX options are turned into -X=0 by util.cpp, therefore the
+// parameter must be accessed as '-segwitfork' and the default below pertains
+// to that.
+const bool DEFAULT_TRIGGER_ON_SEGWIT = true;
+
 extern std::string ForkCmdLineHelp();  // fork-specific command line option help (MVHF-BU-DES-TRIG-8)
 extern void ForkSetup(const CChainParams& chainparams);  // actions to perform at program setup (parameter validation etc.)
 extern void ActivateFork(int actualForkHeight, bool doBackup=true);  // actions to perform at fork triggering (MVHF-BU-DES-TRIG-6)

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -30,7 +30,7 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
     if ((pindexLast->nHeight+1) % params.DifficultyAdjustmentInterval() != 0)
     {
         // MVF-BU: added force-retarget parameter to enable adjusting difficulty for regtest tests
-        if (params.fPowAllowMinDifficultyBlocks && !GetBoolArg("-force-retarget", false))
+        if (params.fPowAllowMinDifficultyBlocks && !GetBoolArg("-force-retarget", DEFAULT_FORCE_RETARGET))
         {
             // Special difficulty rule for testnet:
             // If the new block's timestamp is more than 2* 10 minutes
@@ -61,7 +61,7 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
 unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params& params)
 {
     // MVF-BU: added force-retarget parameter to enable adjusting difficulty for regtest tests
-    if (params.fPowNoRetargeting && !GetBoolArg("-force-retarget", false))
+    if (params.fPowNoRetargeting && !GetBoolArg("-force-retarget", DEFAULT_FORCE_RETARGET))
         return pindexLast->nBits;
 
     // Limit adjustment step
@@ -150,7 +150,7 @@ unsigned int GetMVFNextWorkRequired(const CBlockIndex* pindexLast, const CBlockH
 
 unsigned int CalculateMVFNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params& params)
 {
-    bool force_retarget=GetBoolArg("-force-retarget", false);  // MVF-BU added for retargeting tests on regtestnet (MVHF-BU-DES-DIAD-6)
+    bool force_retarget=GetBoolArg("-force-retarget", DEFAULT_FORCE_RETARGET);  // MVF-BU added for retargeting tests on regtestnet (MVHF-BU-DES-DIAD-6)
     const arith_uint256 bnPowLimit = UintToArith256(params.powLimit); // MVF-BU moved here
 
     if (params.fPowNoRetargeting && !force_retarget)
@@ -257,7 +257,7 @@ bool CheckProofOfWork(uint256 hash, unsigned int nBits, const Consensus::Params&
     bool fNegative;
     bool fOverflow;
     arith_uint256 bnTarget;
-    static bool force_retarget=GetBoolArg("-force-retarget", false);  // MVF-BU (MVHF-BU-DES-DIAD-6)
+    static bool force_retarget=GetBoolArg("-force-retarget", DEFAULT_FORCE_RETARGET);  // MVF-BU (MVHF-BU-DES-DIAD-6)
 
     bnTarget.SetCompact(nBits, &fNegative, &fOverflow);
 


### PR DESCRIPTION
This is added to troubleshoot fork activation interference with certain qa tests which possibly activate SW as a side effect on regtest network.

The default value is that SW activation causes the HF to trigger.
This can be disable by specifying `--nosegwitfork` on the command line.

NOTE: there is currently no option to disable the hard fork on block height. The only way is to specify a very large block height to move the fork activation out of the near future.

It may be useful to investigate if a forkheight=0 should be supported, to disable forking logic entirely, mainly as a safe configuration option for the time after the fork has already activated.