### PR TITLE
Req8/retarget

### DIFF
--- a/qa/rpc-tests/mvf-bu-retarget.py
+++ b/qa/rpc-tests/mvf-bu-retarget.py
@@ -15,7 +15,7 @@ from random import randint
 
 # period (in blocks) from fork activation until retargeting returns to normal
 # MVF-BU TODO: Revert to 180*144
-HARDFORK_RETARGET_BLOCKS = 90*144    # the period when retargeting returns to original
+HARDFORK_RETARGET_BLOCKS = 180*144    # the period when retargeting returns to original
 FORK_BLOCK = 2020                    # needs to be >= 2018 to test fork difficulty reset
 POW_LIMIT = 0x207fffff
 PREFORK_BLOCKTIME = 800              # the seconds for a block during the regtest prefork
@@ -285,6 +285,8 @@ class MVF_RETARGET_Test(BitcoinTestFramework):
             # Test the interval matches the interval defined in params.DifficultyAdjustmentInterval()
             if n >= HARDFORK_RETARGET_BLOCKS :                      # outside MVF retarget period
                 diff_interval_expected = ORIGINAL_DIFFADJINTERVAL  # every 14 days original
+
+            # notice the range() high setting is plus one versus c++ switch
             elif n in range(0,2017) :
                 diff_interval_expected = 1     # retarget every block
             elif n in range(2017,4000) :
@@ -295,7 +297,7 @@ class MVF_RETARGET_Test(BitcoinTestFramework):
                 diff_interval_expected = 100
             elif n in range(15000,20000) :
                 diff_interval_expected = 400
-            elif n in range(20000,25000) :
+            elif n in range(20000,25001) :
                 diff_interval_expected = 1000
             else:
                 diff_interval_expected = ORIGINAL_DIFFADJINTERVAL  # every 14 days original

--- a/qa/rpc-tests/mvf-bu-retarget.py
+++ b/qa/rpc-tests/mvf-bu-retarget.py
@@ -94,15 +94,16 @@ def CalculateMVFResetWorkRequired(bits):
 
 # formula debug testing
 # useful for testing whenever the reset formula changes pow.cpp:CalcForkResetTarget()
-##bits = "1d00ffff" # 1.000000000
-##bits = "201fffff" # 0.0000000019
-##bits = "203ffff6" # 0.0000000009
-##bits = "1f03f355" # 0.0000038624
-#bits = "1e132d35"  # 1e19919b 0.0001527719
+#bits = "1d00ffff" # 1.000000000
+#bits = "201fffff" # 0.0000000019
+#bits = "203ffff6" # 0.0000000009
+#bits = "1f03f355" # 0.0000038624
+#bits = "1e19919b"  # 1e19919b 0.0001527719
+#bits = "1c05a3f4"  # from pow_tests.cpp MVFCheckCalculateMVFResetWorkRequired
 #print "before: 0x%s = %.10f" % (bits,bits2difficulty(int("0x%s"%bits,0)))
 
-##reset = CalculateMVFResetWorkRequired(bits)
-#reset = CalculateMVFNextWorkRequired(bits,800,1)
+#reset = CalculateMVFResetWorkRequired(bits)
+##reset = CalculateMVFNextWorkRequired(bits,800,1)
 #diff = bits2difficulty(reset)
 #print "after : 0x%s = %.10f" % (int2hex(reset),diff)
 #raw_input()

--- a/qa/rpc-tests/mvf-bu-retarget.py
+++ b/qa/rpc-tests/mvf-bu-retarget.py
@@ -191,7 +191,7 @@ class MVF_RETARGET_Test(BitcoinTestFramework):
             prev_block = self.nodes[0].getblock(best_block['previousblockhash'], True)
 
             # track bits used
-            if (prev_block['bits'] == best_block['bits'] or best_block['height'] == FORK_BLOCK)and n < oneRetargetPeriodAfterMVFRetargetPeriod -1 :
+            if (prev_block['bits'] == best_block['bits'] or best_block['height'] == FORK_BLOCK) and n < oneRetargetPeriodAfterMVFRetargetPeriod -1 :
                 count_bits_used += 1
             else:
                 # when the bits change then output the retargeting metrics
@@ -199,10 +199,9 @@ class MVF_RETARGET_Test(BitcoinTestFramework):
                 print_block = self.nodes[0].getblock(self.nodes[0].getblockhash(prev_block['height'] - count_bits_used))
                 avgDeltaBlockTime = (prev_block['time'] - print_block['time']) / count_bits_used
 
-                if n >= HARDFORK_RETARGET_BLOCKS :
-                    # returns to original targetting
-                    nextBits = "original"
-                else:
+                if n == oneRetargetPeriodAfterMVFRetargetPeriod -1 :
+                    nextBits = "end"
+                else :
                     # Test difficulty during MVF retarget period
                     first_block = self.nodes[0].getblock(self.nodes[0].getblockhash(prev_block['height'] - timespanblocks))
                     actualBlockTimeSecs = prev_block['time'] - first_block['time']
@@ -284,11 +283,8 @@ class MVF_RETARGET_Test(BitcoinTestFramework):
             self.nodes[0].setmocktime(best_block['time'] + next_block_time)
 
             # Test the interval matches the interval defined in params.DifficultyAdjustmentInterval()
-            if n >= HARDFORK_RETARGET_BLOCKS :                      # outside MVF retarget period
-                diff_interval_expected = ORIGINAL_DIFFADJINTERVAL  # every 14 days original
-
             # notice the range() high setting is plus one versus c++ switch
-            elif n in range(0,2017) :
+            if n in range(0,2017) :
                 diff_interval_expected = 1     # retarget every block
             elif n in range(2017,4000) :
                 diff_interval_expected = 10
@@ -298,7 +294,7 @@ class MVF_RETARGET_Test(BitcoinTestFramework):
                 diff_interval_expected = 100
             elif n in range(15000,20000) :
                 diff_interval_expected = 400
-            elif n in range(20000,25001) :
+            elif n in range(20000,HARDFORK_RETARGET_BLOCKS+1) :
                 diff_interval_expected = 1000
             else:
                 diff_interval_expected = ORIGINAL_DIFFADJINTERVAL  # every 14 days original

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -91,7 +91,7 @@ struct Params {
 
                 case    10000 ... 14999 : return nPowTargetSpacing * 576;   // 96 hours - 4 days
 
-                case    15000 ... 25000 : return nPowTargetSpacing * 1152;  // 192 hours - 8 days
+                case    15000 ... HARDFORK_RETARGET_BLOCKS : return nPowTargetSpacing * 1152;  // 192 hours - 8 days
 
                 default : return nPowTargetTimespan;    // original 14 days
             }
@@ -101,7 +101,7 @@ struct Params {
 
     bool MVFisWithinRetargetPeriod(int Height) const
     {
-        if (Height >= FinalActivateForkHeight && Height < MVFRetargetPeriodEnd())
+        if (Height >= FinalActivateForkHeight)
             return true;
         else
             return false;
@@ -127,7 +127,7 @@ struct Params {
 
                 case    15000 ... 19999:    return 400;    // every 400 blocks
 
-                case    20000 ... 25000:    return 1000;  // every 1000 blocks
+                case    20000 ... HARDFORK_RETARGET_BLOCKS:    return 1000;  // every 1000 blocks
 
                 default : return 2016;                      // every 2016 blocks
             }

--- a/src/mvf-bu.h
+++ b/src/mvf-bu.h
@@ -29,7 +29,7 @@ HARDFORK_HEIGHT_REGTEST = 9999999,   // regression test network (local)  trigger
 
 // MVHF-BU-DES-DIAD-3 / MVHF-BU-DES-DIAD-4
 // period (in blocks) from fork activation until retargeting returns to normal
-HARDFORK_RETARGET_BLOCKS = 90*144,    // MVF-BU TODO: Revert after testing to 180*144 (25920) blocks
+HARDFORK_RETARGET_BLOCKS = 180*144,    // MVF-BU TODO: Revert after testing to 180*144 (25920) blocks
 
 // MVHF-BU-DES-NSEP-1 - network separation parameter defaults
 // MVF-BU TODO: re-check that these port values could be used

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -79,6 +79,7 @@ unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nF
     bnNew.SetCompact(pindexLast->nBits);
     bnOld = bnNew;
     bnNew *= nActualTimespan;
+    if (bnNew / nActualTimespan != bnOld) bnNew = bnPowLimit; else //MVF-BU Add overflow handle
     bnNew /= params.nPowTargetTimespan;
 
     if (bnNew > bnPowLimit)

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -79,7 +79,6 @@ unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nF
     bnNew.SetCompact(pindexLast->nBits);
     bnOld = bnNew;
     bnNew *= nActualTimespan;
-    if (bnNew / nActualTimespan != bnOld) bnNew = bnPowLimit; else //MVF-BU Add overflow handle
     bnNew /= params.nPowTargetTimespan;
 
     if (bnNew > bnPowLimit)

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -122,6 +122,30 @@ BOOST_AUTO_TEST_CASE(MVFCheckOverflowCalculation_test)
     SoftSetBoolArg("-force-retarget", true);
     BOOST_CHECK_EQUAL(CalculateMVFNextWorkRequired(&pindexLast, nLastRetargetTime, params), bnPowLimit.GetCompact());
 }
+
+/* added unit test for fork reset. doesn't test easily in regtest
+ * because takes some retargets before raising bits off the limit  */
+BOOST_AUTO_TEST_CASE(MVFCheckCalculateMVFResetWorkRequired)
+{
+    SelectParams(CBaseChainParams::REGTEST);
+    const Consensus::Params& params = Params().GetConsensus();
+    const arith_uint256 bnPowLimit = UintToArith256(params.powLimit); // MVF-BU moved here
+
+    // define last block
+    CBlockIndex pindexLast;
+    pindexLast.nHeight = 68543;
+    pindexLast.nTime = 1279297671;  // Block #68543
+    pindexLast.nBits = 0x1c05a3f4;
+
+    // retarget time for test
+    int64_t nLastRetargetTime = pindexLast.nTime - (params.nPowTargetSpacing * params.DifficultyAdjustmentInterval());
+
+    // force retargeting in CalculateMVFNextWorkRequired
+    SoftSetBoolArg("-force-retarget", true);
+
+    // test for drop factor x4
+    BOOST_CHECK_EQUAL(CalculateMVFResetWorkRequired(&pindexLast, nLastRetargetTime, params), 0x1c168fcf);
+}
 // MVF-BU end
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The original CalculateNextWorkRequired() has an overflow bug which perhaps doesn't impact at 14 days retarget intervals but with the fork reset and post fork retargeting the overflow handle is necessary. EDIT see below because unless the fork reset needs to be tested within regtest the new unit test MVFCheckCalculateMVFResetWorkRequired will suffice.
