### PR TITLE
adjustments for running Travis

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -307,15 +307,18 @@ def runtests():
         # weed out the disabled / skipped tests and print them beforehand
         # this allows earlier intervention in case a test is unexpectedly
         # skipped
+        trimmed_tests_to_run = []
         for t in tests_to_run:
             if t.is_disabled():
                 print("Disabled testscript %s%s%s (reason: %s)" % (bold[1], t, bold[0], t.reason))
                 disabled.append(str(t))
-                tests_to_run.remove(t)
             elif t.is_skipped():
                 print("Skipping testscript %s%s%s on this platform (reason: %s)" % (bold[1], t, bold[0], t.reason))
                 skipped.append(str(t))
-                tests_to_run.remove(t)
+            else:
+                trimmed_tests_to_run.append(t)
+
+        tests_to_run = trimmed_tests_to_run
 
         #print "tests after trimming disabled/skipped:"
         #print tests_to_run

--- a/qa/rpc-tests/mvf-bu-retarget.py
+++ b/qa/rpc-tests/mvf-bu-retarget.py
@@ -110,7 +110,11 @@ def CalculateMVFResetWorkRequired(bits):
 #assert_equal(0,1)
 # end debug testing
 
-class MVF_RETARGET_Test(BitcoinTestFramework):
+class MVF_RETARGET_BlockHeight_Test(BitcoinTestFramework):
+
+    def add_options(self, parser):
+        parser.add_option("--quick", dest="quick", default=False, action="store_true",
+        help="Run shortened version of test")
 
     def setup_chain(self):
         # random seed is initialized and output by the test framework
@@ -120,8 +124,12 @@ class MVF_RETARGET_Test(BitcoinTestFramework):
     def setup_network(self):
         self.nodes = []
         self.is_network_split = False
+        # the blockversion below implicitly disables SegWit fork
+        #self.nodes.append(start_node(0, self.options.tmpdir
+        #    ,["-forkheight=%s"%FORK_BLOCK, "-force-retarget","-rpcthreads=100","-blockversion=%s" % "0x20000000" ]
+        #    ))
         self.nodes.append(start_node(0, self.options.tmpdir
-            ,["-forkheight=%s"%FORK_BLOCK, "-force-retarget","-rpcthreads=100","-blockversion=%s" % "0x20000000" ]
+            ,["-forkheight=%s"%FORK_BLOCK, "-rpcthreads=100","-blockversion=%s" % "0x20000000" ]
             ))
 
     def is_fork_triggered_on_node(self, node=0):
@@ -133,6 +141,8 @@ class MVF_RETARGET_Test(BitcoinTestFramework):
         return (len(hf_active) > 0 and len(fork_actions_performed) == 1)
 
     def run_test(self):
+        if not self.options.quick:
+            return True
         # check that fork does not trigger before the forkheight
         print "Generating %s pre-fork blocks" % (FORK_BLOCK - 1)
 
@@ -144,6 +154,14 @@ class MVF_RETARGET_Test(BitcoinTestFramework):
             preblocktime = preblocktime + PREFORK_BLOCKTIME
             self.nodes[0].setmocktime(preblocktime)
             self.nodes[0].generate(1)
+
+        print "Done generating %s pre-fork blocks" % (FORK_BLOCK - 1)
+        print "Stopping node 0"
+        stop_node(self.nodes[0],0)
+        print "Restarting node 0 with -force-retarget"
+        self.nodes[0] = start_node(0, self.options.tmpdir
+            ,["-forkheight=%s"%FORK_BLOCK, "-force-retarget", "-rpcthreads=100","-blockversion=%s" % "0x20000000" ]
+            )
 
         # Read difficulty before the fork
         best_block = self.nodes[0].getblock(self.nodes[0].getbestblockhash(), True)
@@ -185,7 +203,15 @@ class MVF_RETARGET_Test(BitcoinTestFramework):
 
         # start generating MVF blocks with varying time stamps
         oneRetargetPeriodAfterMVFRetargetPeriod = HARDFORK_RETARGET_BLOCKS+ORIGINAL_DIFFADJINTERVAL+1
-        for n in xrange(oneRetargetPeriodAfterMVFRetargetPeriod):
+        if self.options.quick:
+            # used for CI - just test one day after fork
+            # this is basically just to test reset and initial response
+            number_of_blocks_to_test_after_fork = 144
+        else:
+            # full range
+            number_of_blocks_to_test_after_fork = oneRetargetPeriodAfterMVFRetargetPeriod = HARDFORK_RETARGET_BLOCKS+ORIGINAL_DIFFADJINTERVAL+1
+
+        for n in xrange(number_of_blocks_to_test_after_fork):
             best_block = self.nodes[0].getblock(self.nodes[0].getbestblockhash(), True)
             prev_block = self.nodes[0].getblock(best_block['previousblockhash'], True)
 
@@ -325,4 +351,4 @@ class MVF_RETARGET_Test(BitcoinTestFramework):
         #raw_input() # uncomment here to pause shutdown and check the logs
 
 if __name__ == '__main__':
-    MVF_RETARGET_Test().main()
+    MVF_RETARGET_BlockHeight_Test().main()

--- a/qa/rpc-tests/mvf-bu-retarget.py
+++ b/qa/rpc-tests/mvf-bu-retarget.py
@@ -141,8 +141,6 @@ class MVF_RETARGET_BlockHeight_Test(BitcoinTestFramework):
         return (len(hf_active) > 0 and len(fork_actions_performed) == 1)
 
     def run_test(self):
-        if not self.options.quick:
-            return True
         # check that fork does not trigger before the forkheight
         print "Generating %s pre-fork blocks" % (FORK_BLOCK - 1)
 


### PR DESCRIPTION
the long `mvf-bu-retarget.py` has been moved to the extended section, and it now accepts a `--quick` argument which runs only a subset of the post-fork retargeting. This brings the test's duration down significantly, hopefully enough to allow us to run Travis with it.

Also added better handling of options -- now it is possible to specify a test plus its option on the `rpc-tests.py` command line and it will be run correctly (including running the test only with that option, not twice if included in both regular and extended).

A new `-force-enable` (-f) option is added to execute Disabled/Skipped tests, which is useful when you don't want to permanently re-enable them, but tentatively test them.

As this is the first PR, it is expected that Travis will refuse to execute but mark the repo as suspect as it will probably misinterpret the tests as Bitcoin mining.