### PR TITLE
return exit code 1 if any qa tests failed

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -400,6 +400,10 @@ def runtests():
                                                                        len(test_passed))
             print "%d test(s) disabled / %d test(s) skipped due to platform" % (len(disabled), len(skipped))
 
+        # signal that tests have failed using exit code
+        if test_passed.values().count(False):
+            sys.exit(1)
+
     else:
         print "No rpc tests to run. Wallet, utils, and bitcoind must all be enabled"
 


### PR DESCRIPTION
Since we catch and collect test failures now for reporting, we need to explicitly return a non-zero exit code if there have been failed tests. Not returning the exit code may interfere with CI systems such as Travis.

Verified using:
```
qa/pull-tester/rpc-tests.py bip9-softforks ; echo $?
```