### PR TITLE
Do not trigger a softfork backup if backup of prefork block exists

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -76,18 +76,18 @@ private_double_opts = ('--list',
                        '--only-extended',
                        '--force-enable',
                        '--win')
-test_script_opts = ('--tracerpc',
-                    '--help',
-                    '--noshutdown',
-                    '--nocleanup',
-                    '--srcdir',
-                    '--tmpdir',
-                    '--coveragedir',
-                    '--mineblock',
-                    '--quick',
-                    '--randomseed',
-                    '--testbinary',
-                    '--refbinary')
+framework_opts = ('--tracerpc',
+                  '--help',
+                  '--noshutdown',
+                  '--nocleanup',
+                  '--srcdir',
+                  '--tmpdir',
+                  '--coveragedir',
+                  '--randomseed',
+                  '--testbinary',
+                  '--refbinary')
+test_script_opts = ('--mineblock',
+                    '--quick')
 
 def option_passed(option_without_dashes):
     """check if option was specified in single-dash or double-dash format"""
@@ -121,7 +121,7 @@ bad_opts_found = []
 bad_opt_str="Unrecognized option: %s"
 for o in opts | double_opts:
     if o.startswith('--'):
-        if o not in test_script_opts + private_double_opts:
+        if o not in framework_opts + test_script_opts + private_double_opts:
             print bad_opt_str % o
             bad_opts_found.append(o)
     elif o.startswith('-'):
@@ -285,17 +285,23 @@ def runtests():
                             if all_args_found:
                                 tests_to_run.append(t)
                                 found = True
-                        elif str(t) == o or str(t) == o + '.py': 
-                            # it is a test without args - just add it or only add it if no passed on args?
-                            if not passOn:
+                        elif t_rep[0] == o or t_rep[0] == o + '.py':
+                            passOnSplit = [x for x in passOn.split(' ') if x != '']
+                            found_non_framework_opt = False
+                            for p in passOnSplit:
+                                if p in test_script_opts:
+                                    found_non_framework_opt = True
+                            if not found_non_framework_opt:
                                 tests_to_run.append(t)
                                 found = True
                     if not found:
                         print "Error: %s is not a known test." % o
                         sys.exit(1)
 
-        #print "tests after explicit collection:"
-        #print tests_to_run
+        #if len(tests_to_run):
+        #    print "tests explicitly specified:"
+        #    for t in tests_to_run:
+        #        print t
 
         # if no explicit tests specified, use the lists
         if not len(tests_to_run):

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -62,6 +62,7 @@ BITCOIN_TESTS =\
   test/merkle_tests.cpp \
   test/miner_tests.cpp \
   test/multisig_tests.cpp \
+  test/mvfstandalone_tests.cpp \
   test/netbase_tests.cpp \
   test/pmt_tests.cpp \
   test/policyestimator_tests.cpp \

--- a/src/mvf-bu.h
+++ b/src/mvf-bu.h
@@ -84,5 +84,6 @@ extern std::string ForkCmdLineHelp();  // fork-specific command line option help
 extern void ForkSetup(const CChainParams& chainparams);  // actions to perform at program setup (parameter validation etc.)
 extern void ActivateFork(int actualForkHeight, bool doBackup=true);  // actions to perform at fork triggering (MVHF-BU-DES-TRIG-6)
 extern void DeactivateFork(void);  // actions to revert if reorg deactivates fork (MVHF-BU-DES-TRIG-7)
+extern std::string MVFexpandWalletAutoBackupPath(const std::string& strDest, const std::string& strWalletFile, int BackupBlock, bool createDirs=true); // returns the finalized path of the auto wallet backup file (MVHF-BU-DES-WABU-2)
 
 #endif

--- a/src/test/mvfstandalone_tests.cpp
+++ b/src/test/mvfstandalone_tests.cpp
@@ -1,0 +1,45 @@
+// Copyright (c) 2012-2015 The Bitcoin Core developers
+// Copyright (c) 2015-2016 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <iostream>
+#include <boost/test/unit_test.hpp>
+
+#include "wallet/wallet.h"
+#include "mvf-bu.h"
+#include "test/test_bitcoin.h"
+
+BOOST_FIXTURE_TEST_SUITE(mvfstandalone_tests, BasicTestingSetup)
+
+// tests of the wallet backup filename construction
+BOOST_AUTO_TEST_CASE(wallet_backup_path_expansion)
+{
+    boost::filesystem::path datadir = GetDataDir();
+    std::string dds = datadir.string();
+    static const boost::filesystem::path abspath = "/abs";
+    static const boost::filesystem::path relpath = "rel";
+    static const boost::filesystem::path fullpath = datadir / "w@.dat";
+
+    // if first arg is empty, then datadir is prefixed
+    BOOST_CHECK_EQUAL(MVFexpandWalletAutoBackupPath("", "w.dat", 0, false),
+                      datadir / "w.dat.auto.0.bak");
+
+    // if first arg is relative, then datadir is still prefixed
+    BOOST_CHECK_EQUAL(MVFexpandWalletAutoBackupPath("dir", "w.dat", 1, false),
+                      datadir / "dir" / "w.dat.auto.1.bak");
+
+    // if first arg is absolute, then datadir is not prefixed
+    BOOST_CHECK_EQUAL(MVFexpandWalletAutoBackupPath(abspath.string(), "w.dat", 2, false),
+                      abspath / "w.dat.auto.2.bak");
+
+    // if path contains @ it is replaced by height
+    BOOST_CHECK_EQUAL(MVFexpandWalletAutoBackupPath("@@@", "w@.dat", 7, false),
+                      datadir / "777" / "w7.dat.auto.7.bak");
+
+    // if first contains filename, then appending of filename is skipped
+    BOOST_CHECK_EQUAL(MVFexpandWalletAutoBackupPath(fullpath.string(), "w.dat", 6, false),
+                      datadir / "w6.dat");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/mvfstandalone_tests.cpp
+++ b/src/test/mvfstandalone_tests.cpp
@@ -3,12 +3,13 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <iostream>
 #include <boost/test/unit_test.hpp>
 
-#include "wallet/wallet.h"
 #include "mvf-bu.h"
 #include "test/test_bitcoin.h"
+#ifdef ENABLE_WALLET
+#include "wallet/wallet.h"
+#endif
 
 BOOST_FIXTURE_TEST_SUITE(mvfstandalone_tests, BasicTestingSetup)
 
@@ -21,6 +22,7 @@ BOOST_AUTO_TEST_CASE(wallet_backup_path_expansion)
     static const boost::filesystem::path relpath = "rel";
     static const boost::filesystem::path fullpath = datadir / "w@.dat";
 
+#ifdef ENABLE_WALLET
     // if first arg is empty, then datadir is prefixed
     BOOST_CHECK_EQUAL(MVFexpandWalletAutoBackupPath("", "w.dat", 0, false),
                       datadir / "w.dat.auto.0.bak");
@@ -40,6 +42,7 @@ BOOST_AUTO_TEST_CASE(wallet_backup_path_expansion)
     // if first contains filename, then appending of filename is skipped
     BOOST_CHECK_EQUAL(MVFexpandWalletAutoBackupPath(fullpath.string(), "w.dat", 6, false),
                       datadir / "w6.dat");
+#endif
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1048,16 +1048,25 @@ CAmount CWallet::GetChange(const CTransaction& tx) const
 // MVF-BU begin auto wallet backup procedure (MVHF-BU-DES-WABU-4)
 bool CWallet::BackupWalletAuto(const std::string& strDest, int BackupBlock)
 {
-    boost::filesystem::path pathBackupWallet = MVFexpandWalletAutoBackupPath(strDest, strWalletFile, BackupBlock);
-    std::string strBackupFile = pathBackupWallet.string();
+    // check if backup from previous block exists
+    boost::filesystem::path pathBackupWalletPrev = MVFexpandWalletAutoBackupPath(strDest, strWalletFile, BackupBlock-1, false);
+    std::string strBackupFile = pathBackupWalletPrev.string();
+    if (boost::filesystem::exists(strBackupFile)) {
+		LogPrintf("MVF: Wallet was already backed on previous block: %s\n",strBackupFile);
+        return true;
+    }
 
+    // no previous-block backup found, so carry on...
+    // get final backup path (and create directories for it as needed)
+    boost::filesystem::path pathBackupWallet = MVFexpandWalletAutoBackupPath(strDest, strWalletFile, BackupBlock);
     // rename with .old suffix if target already exists
+    strBackupFile = pathBackupWallet.string();
     if (boost::filesystem::exists(strBackupFile))
         boost::filesystem::rename(strBackupFile,strprintf("%s.%s.old",strBackupFile,GetTime()));
 
     // call common backup wallet function
 	if (BackupWallet(*this, strBackupFile))
-		LogPrintf("Wallet automatically backed up to: %s\n",strBackupFile);
+		LogPrintf("MVF: Wallet automatically backed up to: %s\n",strBackupFile);
 	else
 		// backup failed
 		return false;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1045,38 +1045,11 @@ CAmount CWallet::GetChange(const CTransaction& tx) const
     return nChange;
 }
 
-
-
 // MVF-BU begin auto wallet backup procedure (MVHF-BU-DES-WABU-4)
 bool CWallet::BackupWalletAuto(const std::string& strDest, int BackupBlock)
 {
-    boost::filesystem::path pathBackupWallet = strDest;
-
-    //if the backup destination is blank
-    if (strDest == "")
-    {
-        // then prefix it with the existing data dir and wallet filename
-        pathBackupWallet = GetDataDir() / strprintf("%s.%s",strWalletFile, autoWalletBackupSuffix);
-    }
-    else {
-        if (pathBackupWallet.is_relative())
-        	// prefix existing data dir
-        	pathBackupWallet = GetDataDir() / pathBackupWallet;
-
-        if (pathBackupWallet.extension() == "")
-            // no custom filename so append the default filename
-            pathBackupWallet /= strprintf("%s.%s",strWalletFile, autoWalletBackupSuffix);
-
-        if (pathBackupWallet.branch_path() != "")
-            // create directories if they don't exist
-            boost::filesystem::create_directories(pathBackupWallet.branch_path());
-    }
-
+    boost::filesystem::path pathBackupWallet = MVFexpandWalletAutoBackupPath(strDest, strWalletFile, BackupBlock);
     std::string strBackupFile = pathBackupWallet.string();
-
-    // replace # with BackupBlock number
-    boost::replace_all(strBackupFile,"@", boost::to_string_stub(BackupBlock));
-    //LogPrintf("DEBUG: strBackupFile=%s\n",strBackupFile);
 
     // rename with .old suffix if target already exists
     if (boost::filesystem::exists(strBackupFile))


### PR DESCRIPTION
This fixes a problem with the wallet backup which occurred under the following sequence of events:

- start, run up to forkheight-1. A backup is created at forkheight-1, but the fork is not yet activated.
- shut down the node.
- start up again. As the fork activates, another backup is created ("soft-fork backup") at with backup block == forkheight. Now there are two backups.

In the course of fixing this, the walletbackupauto.py test has been extended, the backup filepath construction code has been factored out of wallet.cpp and into mvf-bu.cpp, and a new C++ unit test created for it.

The mvfstandalone_tests` module is intended for tests relating to MVF functions that can easily be tested on their own. In future, it can be extended with test cases for the DIAD and perhaps other fork functionality.