### PR TITLE
fix mvfstandalone_tests on Windows platforms

### DIFF
--- a/src/mvf-bu.cpp
+++ b/src/mvf-bu.cpp
@@ -265,12 +265,17 @@ std::string MVFexpandWalletAutoBackupPath(const std::string& strDest, const std:
             // prefix existing data dir
             pathBackupWallet = GetDataDir() / pathBackupWallet;
 
-        if (pathBackupWallet.extension() == "")
-            // no custom filename so append the default filename
+        // if pathBackupWallet is a folder or symlink, or if it does end
+        // on a filename with an extension...
+        if (!pathBackupWallet.has_extension() || (boost::filesystem::is_directory(pathBackupWallet) && boost::filesystem::is_symlink(pathBackupWallet)))
+            // ... we assume no custom filename so append the default filename
             pathBackupWallet /= strprintf("%s.%s",strWalletFile, autoWalletBackupSuffix);
 
         if (pathBackupWallet.branch_path() != "" && createDirs)
             // create directories if they don't exist
+            // MVF-BU TODO: this directory creation should be factored out
+            // so that we do not need to pass a Boolean arg and this function
+            // should not have the side effect. Marked for cleanup.
             boost::filesystem::create_directories(pathBackupWallet.branch_path());
     }
 

--- a/src/test/mvfstandalone_tests.cpp
+++ b/src/test/mvfstandalone_tests.cpp
@@ -16,11 +16,27 @@ BOOST_FIXTURE_TEST_SUITE(mvfstandalone_tests, BasicTestingSetup)
 // tests of the wallet backup filename construction
 BOOST_AUTO_TEST_CASE(wallet_backup_path_expansion)
 {
+    std::string platform(BOOST_PLATFORM);
+
     boost::filesystem::path datadir = GetDataDir();
     std::string dds = datadir.string();
-    static const boost::filesystem::path abspath = "/abs";
-    static const boost::filesystem::path relpath = "rel";
+    static const boost::filesystem::path abspath(GetDataDir());
+    static const boost::filesystem::path relpath("rel");
     static const boost::filesystem::path fullpath = datadir / "w@.dat";
+    static const boost::filesystem::path userpath("/home/user/.bitcoin");
+
+    // sanity checks
+    BOOST_CHECK(abspath.is_absolute());
+    BOOST_CHECK(!abspath.is_relative());
+    BOOST_CHECK(relpath.is_relative());
+    BOOST_CHECK(!relpath.is_absolute());
+    BOOST_CHECK(!relpath.has_root_directory());
+    BOOST_CHECK(fullpath.has_filename());
+    BOOST_CHECK(userpath.has_filename());
+    BOOST_CHECK(userpath.has_extension());
+    BOOST_CHECK_EQUAL(userpath.filename(), ".bitcoin");
+    BOOST_CHECK_EQUAL(userpath.extension(), ".bitcoin");
+    BOOST_CHECK_EQUAL(userpath.extension(), userpath.filename());
 
 #ifdef ENABLE_WALLET
     // if first arg is empty, then datadir is prefixed


### PR DESCRIPTION
Use GetDataDir() to initialize abspath, this should work around test failure on Travis / Windows platforms hopefully.

The expansion has been improved to check if the provided path is an already existing folder or symlink, in which case it will append the wallet filename + backup extension.