### PR TITLE
btcforks.conf file parsing

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -119,6 +119,7 @@ BITCOIN_CORE_H = \
   merkleblock.h \
   miner.h \
   mvf-bu.h \
+  mvf-btcfork_conf_parser.h \
   net.h \
   leakybucket.h \
   netbase.h \
@@ -208,6 +209,7 @@ libbitcoin_server_a_SOURCES = \
   merkleblock.cpp \
   miner.cpp \
   mvf-bu.cpp \
+  mvf-btcfork_conf_parser.cpp \
   net.cpp \
   noui.cpp \
   policy/fees.cpp \

--- a/src/mvf-btcfork_conf_parser.cpp
+++ b/src/mvf-btcfork_conf_parser.cpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2016 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// MVF-BU common objects and functions
+
+#include <boost/filesystem.hpp>
+#include <boost/filesystem/fstream.hpp>
+#include <boost/program_options/detail/config_file.hpp>
+
+#include "mvf-bu.h"
+#include "mvf-btcfork_conf_parser.h"
+
+/* not sure if we need the following for Clang compatibility (copied this from util.cpp just in case)
+namespace boost {
+
+namespace program_options {
+std::string to_internal(const std::string&);
+}
+
+} // namespace boost
+*/
+
+using namespace std;
+
+// copied from util.cpp:ReadConfigFile with minor simplifications.
+// MVF-BU TOOD: would be good to refactor so we don't need separate procedures
+void MVFReadConfigFile(map<string, string>& mapSettingsRet,
+                       map<string, vector<string> >& mapMultiSettingsRet)
+{
+    boost::filesystem::ifstream streamConfig(MVFGetConfigFile());
+    if (!streamConfig.good())
+        return; // No btcfork.conf file is OK
+
+    set<string> setOptions;
+    setOptions.insert("*");
+
+    for (boost::program_options::detail::config_file_iterator it(streamConfig, setOptions), end; it != end; ++it)
+    {
+        // Don't overwrite existing settings so command line settings override bitcoin.conf
+        string strKey = string("-") + it->string_key;
+        string strValue = it->value[0];
+        if (mapSettingsRet.count(strKey) == 0)
+            mapSettingsRet[strKey] = strValue;
+        mapMultiSettingsRet[strKey].push_back(strValue);
+    }
+}

--- a/src/mvf-btcfork_conf_parser.cpp
+++ b/src/mvf-btcfork_conf_parser.cpp
@@ -3,7 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 // MVF-BU common objects and functions
 
-#include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
 #include <boost/program_options/detail/config_file.hpp>
 
@@ -24,10 +23,11 @@ using namespace std;
 
 // copied from util.cpp:ReadConfigFile with minor simplifications.
 // MVF-BU TOOD: would be good to refactor so we don't need separate procedures
-void MVFReadConfigFile(map<string, string>& mapSettingsRet,
+void MVFReadConfigFile(boost::filesystem::path pathCfgFile,
+                       map<string, string>& mapSettingsRet,
                        map<string, vector<string> >& mapMultiSettingsRet)
 {
-    boost::filesystem::ifstream streamConfig(MVFGetConfigFile());
+    boost::filesystem::ifstream streamConfig(pathCfgFile);
     if (!streamConfig.good())
         return; // No btcfork.conf file is OK
 

--- a/src/mvf-btcfork_conf_parser.h
+++ b/src/mvf-btcfork_conf_parser.h
@@ -6,10 +6,12 @@
 #ifndef BITCOIN_MVF_BTCFORK_CONF_PARSER_H
 #define BITCOIN_MVF_BTCFORK_CONF_PARSER_H
 
+#include <boost/filesystem.hpp>
+
 #include "mvf-bu.h"
 
 // read btcfork.conf file
-extern void MVFReadConfigFile(std::map<std::string, std::string>& mapSettingsRet, std::map<std::string, std::vector<std::string> >& mapMultiSettingsRet);
+extern void MVFReadConfigFile(boost::filesystem::path pathCfgFile, std::map<std::string, std::string>& mapSettingsRet, std::map<std::string, std::vector<std::string> >& mapMultiSettingsRet);
 
 #endif
 

--- a/src/mvf-btcfork_conf_parser.h
+++ b/src/mvf-btcfork_conf_parser.h
@@ -1,0 +1,15 @@
+// Copyright (c) 2016 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// MVF-BU common declarations
+#pragma once
+#ifndef BITCOIN_MVF_BTCFORK_CONF_PARSER_H
+#define BITCOIN_MVF_BTCFORK_CONF_PARSER_H
+
+#include "mvf-bu.h"
+
+// read btcfork.conf file
+extern void MVFReadConfigFile(std::map<std::string, std::string>& mapSettingsRet, std::map<std::string, std::vector<std::string> >& mapMultiSettingsRet);
+
+#endif
+

--- a/src/mvf-bu.cpp
+++ b/src/mvf-bu.cpp
@@ -99,10 +99,6 @@ void ForkSetup(const CChainParams& chainparams)
         throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, activeNetworkID));
 
     FinalActivateForkHeight = GetArg("-forkheight", minForkHeightForNetwork);
-    if (mapArgs.count("-autobackupblock") == 0) {
-        // default value for backup block is 1 block prior to fixed fork trigger
-        mapArgs["-autobackupblock"] = FinalActivateForkHeight - 1;
-    }
 
     // check if btcfork.conf exists (MVHF-BU-DES-TRIG-10)
     boost::filesystem::path pathBTCforkConfigFile(BTCFORK_CONF_FILENAME);
@@ -165,7 +161,7 @@ void ForkSetup(const CChainParams& chainparams)
         LogPrintf("%s: MVF: Segregated Witness trigger is ENABLED\n", __func__);
     else
         LogPrintf("%s: MVF: Segregated Witness trigger is DISABLED\n", __func__);
-    LogPrintf("%s: MVF: auto backup block = %d\n", __func__, atoi(mapArgs["-autobackupblock"]));
+    LogPrintf("%s: MVF: auto backup block = %d\n", __func__, GetArg("-autobackupblock", FinalActivateForkHeight - 1));
 
     if (GetBoolArg("-force-retarget", DEFAULT_FORCE_RETARGET))
         LogPrintf("%s: MVF: force-retarget is ENABLED\n", __func__);

--- a/src/mvf-bu.cpp
+++ b/src/mvf-bu.cpp
@@ -101,15 +101,13 @@ void ForkSetup(const CChainParams& chainparams)
     FinalActivateForkHeight = GetArg("-forkheight", minForkHeightForNetwork);
 
     // check if btcfork.conf exists (MVHF-BU-DES-TRIG-10)
-    boost::filesystem::path pathBTCforkConfigFile(BTCFORK_CONF_FILENAME);
-    if (!pathBTCforkConfigFile.is_complete())
-        pathBTCforkConfigFile = GetDataDir(false) / pathBTCforkConfigFile;
+    boost::filesystem::path pathBTCforkConfigFile(MVFGetConfigFile());
     if (boost::filesystem::exists(pathBTCforkConfigFile)) {
         LogPrintf("%s: MVF: found marker config file at %s - client has already forked before\n", __func__, pathBTCforkConfigFile.string().c_str());
         // read the btcfork.conf file if it exists, override standard config values using its configuration
         try
         {
-            MVFReadConfigFile(btcforkMapArgs, btcforkMapMultiArgs);
+            MVFReadConfigFile(pathBTCforkConfigFile, btcforkMapArgs, btcforkMapMultiArgs);
             if (btcforkMapArgs.count("-forkheight")) {
                 FinalActivateForkHeight = atoi(btcforkMapArgs["-forkheight"]);
                 mapArgs["-forkheight"] = FinalActivateForkHeight;
@@ -209,7 +207,7 @@ void ActivateFork(int actualForkHeight, bool doBackup)
         }
         // try to write the btcfork.conf (MVHF-BU-DES-TRIG-10)
         LogPrintf("%s: MVF: writing %s\n", __func__, pathBTCforkConfigFile.string().c_str());
-        std::ofstream  btcforkfile(pathBTCforkConfigFile.string().c_str(), std::ios::out);
+        std::ofstream btcforkfile(pathBTCforkConfigFile.string().c_str(), std::ios::out);
         btcforkfile << "forkheight=" << FinalActivateForkHeight << "\n";
         btcforkfile << "forkid=" << FinalForkId << "\n";
 

--- a/src/mvf-bu.h
+++ b/src/mvf-bu.h
@@ -6,9 +6,18 @@
 #ifndef BITCOIN_MVF_BU_H
 #define BITCOIN_MVF_BU_H
 
+#include <boost/filesystem.hpp>
+
 #include "protocol.h"
 
 class CChainParams;
+
+// MVHF-BU-DES-TRIG-10 - config file that is written when forking, and used to detect "forked" condition at start
+const char * const BTCFORK_CONF_FILENAME = "btcfork.conf";
+
+// btcfork.conf configuration key-value maps (MVF TODO: reference associated design)
+extern std::map<std::string, std::string> btcforkMapArgs;
+extern std::map<std::string, std::vector<std::string> > btcforkMapMultiArgs;
 
 extern int FinalActivateForkHeight;             // MVHF-BU-DES-TRIG-4
 extern bool wasMVFHardForkPreviouslyActivated;  // MVHF-BU-DES-TRIG-5
@@ -67,9 +76,6 @@ static const uint256 HARDFORK_POWRESET_MAINNET = uint256S("00007ffffffffffffffff
                      HARDFORK_POWRESET_NOLNET  = uint256S("3fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),  // nolnet
                      HARDFORK_POWRESET_REGTEST = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");  // regtestnet
 
-// MVHF-BU-DES-TRIG-10 - config file that is written when forking, and used to detect "forked" condition at start
-const char * const BTCFORK_CONF_FILENAME = "btcfork.conf";
-
 // MVHF-BU-DES-DIAD-? -force-retarget option determines  whether to actively retarget on regtest after fork happens
 // (not all tests need that, so the POW/difficulty fork related ones that do specifically invoke this option)
 const bool DEFAULT_FORCE_RETARGET = false;
@@ -81,9 +87,15 @@ const bool DEFAULT_FORCE_RETARGET = false;
 const bool DEFAULT_TRIGGER_ON_SEGWIT = true;
 
 extern std::string ForkCmdLineHelp();  // fork-specific command line option help (MVHF-BU-DES-TRIG-8)
+extern boost::filesystem::path MVFGetConfigFile();  // get the full path to the btcfork.conf file
 extern void ForkSetup(const CChainParams& chainparams);  // actions to perform at program setup (parameter validation etc.)
 extern void ActivateFork(int actualForkHeight, bool doBackup=true);  // actions to perform at fork triggering (MVHF-BU-DES-TRIG-6)
 extern void DeactivateFork(void);  // actions to revert if reorg deactivates fork (MVHF-BU-DES-TRIG-7)
 extern std::string MVFexpandWalletAutoBackupPath(const std::string& strDest, const std::string& strWalletFile, int BackupBlock, bool createDirs=true); // returns the finalized path of the auto wallet backup file (MVHF-BU-DES-WABU-2)
+extern std::string MVFGetArg(const std::string& strArg, const std::string& strDefault);
+extern int64_t MVFGetArg(const std::string& strArg, int64_t nDefault);
+extern bool MVFGetBoolArg(const std::string& strArg, bool fDefault);
+extern bool MFVSoftSetArg(const std::string& strArg, const std::string& strValue);
+extern bool MFVSoftSetBoolArg(const std::string& strArg, bool fValue);
 
 #endif

--- a/src/test/mvfstandalone_tests.cpp
+++ b/src/test/mvfstandalone_tests.cpp
@@ -6,7 +6,10 @@
 #include <boost/test/unit_test.hpp>
 
 #include "mvf-bu.h"
+//#include "mvf-btcfork_conf_parser.h"
+#include "util.h"
 #include "test/test_bitcoin.h"
+
 #ifdef ENABLE_WALLET
 #include "wallet/wallet.h"
 #endif
@@ -59,6 +62,31 @@ BOOST_AUTO_TEST_CASE(wallet_backup_path_expansion)
     BOOST_CHECK_EQUAL(MVFexpandWalletAutoBackupPath(fullpath.string(), "w.dat", 6, false),
                       datadir / "w6.dat");
 #endif
+}
+
+
+BOOST_AUTO_TEST_CASE(btcfork_conf_args)
+{
+    btcforkMapArgs.clear();
+    btcforkMapArgs["strtest1"] = "string...";
+    // strtest2 undefined on purpose
+    btcforkMapArgs["inttest1"] = "12345";
+    btcforkMapArgs["inttest2"] = "81985529216486895";
+    // inttest3 undefined on purpose
+    btcforkMapArgs["booltest1"] = "";
+    // booltest2 undefined on purpose
+    btcforkMapArgs["booltest3"] = "0";
+    btcforkMapArgs["booltest4"] = "1";
+
+    BOOST_CHECK_EQUAL(MVFGetArg("strtest1", "default"), "string...");
+    BOOST_CHECK_EQUAL(MVFGetArg("strtest2", "default"), "default");
+    BOOST_CHECK_EQUAL(MVFGetArg("inttest1", -1), 12345);
+    BOOST_CHECK_EQUAL(MVFGetArg("inttest2", -1), 81985529216486895LL);
+    BOOST_CHECK_EQUAL(MVFGetArg("inttest3", -1), -1);
+    BOOST_CHECK_EQUAL(MVFGetBoolArg("booltest1", false), true);
+    BOOST_CHECK_EQUAL(MVFGetBoolArg("booltest2", false), false);
+    BOOST_CHECK_EQUAL(MVFGetBoolArg("booltest3", false), false);
+    BOOST_CHECK_EQUAL(MVFGetBoolArg("booltest4", false), true);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/mvfstandalone_tests.cpp
+++ b/src/test/mvfstandalone_tests.cpp
@@ -124,6 +124,10 @@ BOOST_AUTO_TEST_CASE(mvfreadconfigfile)
     BOOST_CHECK_EQUAL(atoi(btcforkMapArgs["-forkheight"]), (int)HARDFORK_HEIGHT_REGTEST);
     BOOST_CHECK_EQUAL(atoi(btcforkMapArgs["-forkid"]), (int)HARDFORK_SIGHASH_ID);
     BOOST_CHECK_EQUAL(atoi(btcforkMapArgs["-autobackupblock"]), (int)(HARDFORK_HEIGHT_REGTEST - 1));
+
+    // added so that we can update this test when adding new entries
+    BOOST_CHECK_EQUAL(btcforkMapArgs.size(), 3);
+
     // cleanup
     boost::filesystem::remove(pathBTCforkConfigFile);
     BOOST_CHECK(!boost::filesystem::exists(pathBTCforkConfigFile));

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -326,7 +326,9 @@ int LogPrintStr(const std::string &str)
 }
 
 /** Interpret string as boolean, for argument parsing */
-static bool InterpretBool(const std::string& strValue)
+// MVF-BU begin: removed static and declared extern since used by MVFGetBoolArg
+bool InterpretBool(const std::string& strValue)
+// MVF-BU end
 {
     if (strValue.empty())
         return true;

--- a/src/util.h
+++ b/src/util.h
@@ -138,6 +138,7 @@ boost::filesystem::path GetTempPath();
 void OpenDebugLog();
 void ShrinkDebugFile();
 void runCommand(const std::string& strCommand);
+extern bool InterpretBool(const std::string& strValue);  // MVF-BU: make extern, used by MVFGetBoolArg
 
 inline bool IsSwitchChar(char c)
 {


### PR DESCRIPTION
Long overdue implementation of reading the btcfork.conf file on startup if it is present.

The idea here was that when the fork happens, this file is written out with the key parameters used to fork. This helps the client to recognize at startup that it has forked previously, and can then initialize itself correctly.

Ultimately, the user will be requested to transfer some of the final settings to his bitcoin.conf file, and can then remove the btcfork.conf file entirely. This part is not yet implemented.