### PR TITLE
BFGtest - btc fork genesis testnet

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -308,8 +308,10 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].bit = 0;
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = 1456790400; // March 1st, 2016
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = 1493596800; // May 1st, 2017
+        // MVF-BU end
 
         // MVF-BU begin: added deployment of BIP141/143/147 (MVHF-BU-DES-TRIG-2)
+        // these have been shifted on BFG testnet
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].bit = 1;
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nStartTime = 1483228800; // Jan 1st, 2017
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = 1520035200; // Mar 3rd, 2018

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -19,18 +19,13 @@
 
 #include "chainparamsseeds.h"
 
-/*
-#include <stdio.h>          // MVF-BU only for mining genesis block of bfgtest network
-#include "arith_uint256.h"  // MVF-BU only for mining genesis block of bfgtest network
-*/
-
 static CBlock CreateGenesisBlock(const char* pszTimestamp, const CScript& genesisOutputScript, uint32_t nTime, uint32_t nNonce, uint32_t nBits, int32_t nVersion, const CAmount& genesisReward)
 {
     CMutableTransaction txNew;
     txNew.nVersion = 1;
     txNew.vin.resize(1);
     txNew.vout.resize(1);
-    txNew.vin[0].scriptSig = CScript() << 0x1d00ffff << CScriptNum(4) << std::vector<unsigned char>((const unsigned char*)pszTimestamp, (const unsigned char*)pszTimestamp + strlen(pszTimestamp));  // MVF-BU changed integer to hex to make it clear that it is nBits
+    txNew.vin[0].scriptSig = CScript() << 0x1d00ffff << CScriptNum(4) << std::vector<unsigned char>((const unsigned char*)pszTimestamp, (const unsigned char*)pszTimestamp + strlen(pszTimestamp));
     txNew.vout[0].nValue = genesisReward;
     txNew.vout[0].scriptPubKey = genesisOutputScript;
 
@@ -340,26 +335,8 @@ public:
         const CScript genesisOutputScript = CScript() << ParseHex("76a914d7b6e7527ebbcb86571544d2d934867349baccf388ac");
 
         // replace with generated genesis block (nNonce) - the actual block can be mined at higher difficulty than the given nBits
-        // CreateGenesisBlock(const char* pszTimestamp, const CScript& genesisOutputScript, uint32_t nTime, uint32_t nNonce, uint32_t nBits, int32_t nVersion, const CAmount& genesisReward)
         genesis = CreateGenesisBlock("To boldly fork where no-one has forked before", genesisOutputScript, 1481996048, 3180522, 0x1d7fffff, 0x20000000, CAmount(5000000000));
-        consensus.hashGenesisBlock = genesis.GetHash();  // MVF-BU: temporarily disabled to mine genesis block
-
-        /*
-        // set "false" to "true" and uncomment all code in this block to mine the chain's genesis block
-        consensus.hashGenesisBlock = uint256S("0000000000000000000000000000000000000000000000000000000000000001");
-        arith_uint256 bnTarget = UintToArith256(consensus.powLimit);
-        if (false && genesis.GetHash() != consensus.hashGenesisBlock)
-        {
-            printf("mining genesis block for bfgtest - recalculating params\n");
-            printf("old bfgtest genesis nonce: %u\n", genesis.nNonce);
-            printf("old bfgtest genesis hash:  %s\n", consensus.hashGenesisBlock.ToString().c_str());
-            // deliberately empty for loop finds nonce value.
-            for(genesis.nNonce = 0; UintToArith256(genesis.GetHash()) > bnTarget; genesis.nNonce++){ }
-            printf("new bfgtest genesis merkle root: %s\n", genesis.hashMerkleRoot.ToString().c_str());
-            printf("new bfgtest genesis nonce: %u\n", genesis.nNonce);
-            printf("new bfgtest genesis hash: %s\n", genesis.GetHash().ToString().c_str());
-        }
-        */
+        consensus.hashGenesisBlock = genesis.GetHash();
 
         // update these with the mined genesis params
         assert(consensus.hashGenesisBlock == uint256S("0x0000004557d7deb53c5642a1df3a4becd7d5e748f409d5d68a8677e04cc7cb6c"));

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -25,7 +25,7 @@ static CBlock CreateGenesisBlock(const char* pszTimestamp, const CScript& genesi
     txNew.nVersion = 1;
     txNew.vin.resize(1);
     txNew.vout.resize(1);
-    txNew.vin[0].scriptSig = CScript() << 0x1d00ffff << CScriptNum(4) << std::vector<unsigned char>((const unsigned char*)pszTimestamp, (const unsigned char*)pszTimestamp + strlen(pszTimestamp));
+    txNew.vin[0].scriptSig = CScript() << 0x1d00ffff << CScriptNum(4) << std::vector<unsigned char>((const unsigned char*)pszTimestamp, (const unsigned char*)pszTimestamp + strlen(pszTimestamp));  // MVF-BU: replace magic number by more recognizable nBits value
     txNew.vout[0].nValue = genesisReward;
     txNew.vout[0].scriptPubKey = genesisOutputScript;
 

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -15,12 +15,14 @@ const std::string CBaseChainParams::MAIN = "main";
 const std::string CBaseChainParams::UNL = "nol";
 const std::string CBaseChainParams::TESTNET = "test";
 const std::string CBaseChainParams::REGTEST = "regtest";
+const std::string CBaseChainParams::BFGTEST = "bfgtest";  // MVF-BU
 
 void AppendParamsHelpMessages(std::string& strUsage, bool debugHelp)
 {
     strUsage += HelpMessageGroup(_("Chain selection options:"));
     strUsage += HelpMessageOpt("-testnet", _("Use the test chain"));
     strUsage += HelpMessageOpt("-chain_nol", _("Use the no-limit blockchain"));
+    strUsage += HelpMessageOpt("-bfgtest", _("Use the btcforks genesis test chain"));  // MVF-BU
     if (debugHelp) {
         strUsage += HelpMessageOpt("-regtest", "Enter regression test mode, which uses a special chain in which blocks can be solved instantly. "
                                    "This is intended for regression testing tools and app development.");
@@ -53,6 +55,22 @@ public:
     }
 };
 static CBaseUnlParams unlParams;
+
+// MVF-BU begin
+/**
+ * BFG network
+ */
+class CBaseBFGTestParams : public CBaseChainParams
+{
+public:
+    CBaseBFGTestParams()
+    {
+        nRPCPort = 19887;
+        strDataDir = "bfgtest";
+    }
+};
+static CBaseBFGTestParams bfgTestParams;
+// MVF-BU end
 
 /**
  * Testnet (v3)
@@ -100,6 +118,10 @@ CBaseChainParams& BaseParams(const std::string& chain)
         return testNetParams;
     else if (chain == CBaseChainParams::REGTEST)
         return regTestParams;
+    // MVF-BU begin
+    else if (chain == CBaseChainParams::BFGTEST)
+        return bfgTestParams;
+    // MVF-BU end
     else
         throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));
 }
@@ -114,6 +136,7 @@ std::string ChainNameFromCommandLine()
     bool fRegTest = GetBoolArg("-regtest", false);
     bool fTestNet = GetBoolArg("-testnet", false);
     bool fUnl = GetBoolArg("-chain_nol", false);
+    bool fBFGTest = GetBoolArg("-bfgtest", false);  // MVF-BU
 
     if (fTestNet && fRegTest)
         throw std::runtime_error("Invalid combination of -regtest and -testnet.");
@@ -123,6 +146,10 @@ std::string ChainNameFromCommandLine()
         return CBaseChainParams::TESTNET;
     if (fUnl)
         return CBaseChainParams::UNL;
+    // MVF-BU begin
+    if (fBFGTest)
+        return CBaseChainParams::BFGTEST;
+    // MVF-BU end
     return CBaseChainParams::MAIN;
 }
 

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -21,6 +21,7 @@ public:
     static const std::string UNL;
     static const std::string TESTNET;
     static const std::string REGTEST;
+    static const std::string BFGTEST;  // MVF-BU
 
     const std::string& DataDir() const { return strDataDir; }
     int RPCPort() const { return nRPCPort; }

--- a/src/mvf-bu.cpp
+++ b/src/mvf-bu.cpp
@@ -48,7 +48,7 @@ std::string ForkCmdLineHelp()
     strUsage += HelpMessageOpt("-autobackupblock=<n>", _("Specify the block number that triggers the automatic wallet backup. Default: forkheight-1"));
 
     // fork height parameter (MVHF-BU-DES-TRIG-1)
-    strUsage += HelpMessageOpt("-forkheight=<n>", strprintf(_("Block height at which to fork on active network (integer). Defaults (also minimums): mainnet:%u,testnet=%u,nolnet=%u,regtest=%u"), (unsigned)HARDFORK_HEIGHT_MAINNET, (unsigned)HARDFORK_HEIGHT_TESTNET, (unsigned)HARDFORK_HEIGHT_NOLNET, (unsigned)HARDFORK_HEIGHT_REGTEST));
+    strUsage += HelpMessageOpt("-forkheight=<n>", strprintf(_("Block height at which to fork on active network (integer). Defaults (also minimums): mainnet:%u,testnet=%u,nolnet=%u,regtest=%u,bfgtest=%u"), (unsigned)HARDFORK_HEIGHT_MAINNET, (unsigned)HARDFORK_HEIGHT_TESTNET, (unsigned)HARDFORK_HEIGHT_NOLNET, (unsigned)HARDFORK_HEIGHT_REGTEST, (unsigned)HARDFORK_HEIGHT_BFGTEST));
 
     // fork id (MVHF-BU-DES-CSIG-1)
     strUsage += HelpMessageOpt("-forkid=<n>", strprintf(_("Fork id to use for signature change. Value must be between 0 and %d. Default is 0x%06x (%u)"), (unsigned)MAX_HARDFORK_SIGHASH_ID, (unsigned)HARDFORK_SIGHASH_ID, (unsigned)HARDFORK_SIGHASH_ID));
@@ -76,6 +76,8 @@ void ForkSetup(const CChainParams& chainparams)
         minForkHeightForNetwork = HARDFORK_HEIGHT_REGTEST;
     else if (activeNetworkID == CBaseChainParams::UNL)
         minForkHeightForNetwork = HARDFORK_HEIGHT_NOLNET;
+    else if (activeNetworkID == CBaseChainParams::BFGTEST)
+        minForkHeightForNetwork = HARDFORK_HEIGHT_BFGTEST;
     else
         throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, activeNetworkID));
 

--- a/src/mvf-bu.cpp
+++ b/src/mvf-bu.cpp
@@ -108,6 +108,7 @@ void ForkSetup(const CChainParams& chainparams)
     else if (activeNetworkID == CBaseChainParams::UNL) {
         minForkHeightForNetwork = HARDFORK_HEIGHT_NOLNET;
         defaultDropFactorForNetwork = HARDFORK_DROPFACTOR_NOLNET;
+    }
     else if (activeNetworkID == CBaseChainParams::BFGTEST) {
         minForkHeightForNetwork = HARDFORK_HEIGHT_BFGTEST;
         defaultDropFactorForNetwork = HARDFORK_DROPFACTOR_BFGTEST;

--- a/src/mvf-bu.cpp
+++ b/src/mvf-bu.cpp
@@ -180,6 +180,7 @@ void ForkSetup(const CChainParams& chainparams)
     LogPrintf("%s: MVF: active network = %s\n", __func__, activeNetworkID);
     LogPrintf("%s: MVF: active fork id = 0x%06x (%d)\n", __func__, FinalForkId, FinalForkId);
     LogPrintf("%s: MVF: active fork height = %d\n", __func__, FinalActivateForkHeight);
+    LogPrintf("%s: MVF: active difficulty drop factor = %u\n", __func__, FinalDifficultyDropFactor);
     if (GetBoolArg("-segwitfork", DEFAULT_TRIGGER_ON_SEGWIT))
         LogPrintf("%s: MVF: Segregated Witness trigger is ENABLED\n", __func__);
     else

--- a/src/mvf-bu.h
+++ b/src/mvf-bu.h
@@ -60,6 +60,7 @@ HARDFORK_DROPFACTOR_MAINNET = 100000,  // default difficulty drop on operational
 HARDFORK_DROPFACTOR_TESTNET = 10000,   // default difficulty drop on public test network (testnet)
 HARDFORK_DROPFACTOR_NOLNET = 10000,    // default difficulty drop on BU public no-limit test network (nolnet)
 HARDFORK_DROPFACTOR_REGTEST = 4,       // default difficulty drop on local regression test network (regtestnet)
+HARDFORK_DROPFACTOR_BFGTEST = 1000,    // default difficulty drop on btcforks genesis test network (bfgtest)
 
 // MVHF-BU-DES-NSEP-1 - network separation parameter defaults
 // MVF-BU TODO: re-check that these port values could be used

--- a/src/mvf-bu.h
+++ b/src/mvf-bu.h
@@ -26,6 +26,7 @@ HARDFORK_HEIGHT_MAINNET =  666666,   // operational network trigger height
 HARDFORK_HEIGHT_TESTNET = 9999999,   // public test network trigger height
 HARDFORK_HEIGHT_NOLNET  = 8888888,   // BU public no-limit test network  trigger height
 HARDFORK_HEIGHT_REGTEST = 9999999,   // regression test network (local)  trigger height
+HARDFORK_HEIGHT_BFGTEST = 9999999,   // btcforks genesis test network trigger height
 
 // MVHF-BU-DES-DIAD-3 / MVHF-BU-DES-DIAD-4
 // period (in blocks) from fork activation until retargeting returns to normal
@@ -37,6 +38,7 @@ HARDFORK_PORT_MAINNET = 9442,        // default post-fork port on operational ne
 HARDFORK_PORT_TESTNET = 9443,        // default post-fork port on public test network (testnet)
 HARDFORK_PORT_NOLNET  = 9444,        // default post-fork port on BU public no-limit test network (nolnet)
 HARDFORK_PORT_REGTEST = 19555,       // default post-fork port on local regression test network (regtestnet)
+HARDFORK_PORT_BFGTEST = 19988,       // default post-fork port on btcforks genesis test network (bfgtest)
 
 // MVHF-BU-DES-CSIG-1 - signature change parameter defaults
 HARDFORK_SIGHASH_ID = 0x777000,      // 3 byte fork id that is left-shifted by 8 bits and then ORed with the SIGHASHes
@@ -62,6 +64,7 @@ static const CMessageHeader::MessageStartChars pchMessageStart_HardForkMainnet  
 static const uint256 HARDFORK_POWRESET_MAINNET = uint256S("00007fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),  // mainnet
                      HARDFORK_POWRESET_TESTNET = uint256S("007fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),  // testnet
                      HARDFORK_POWRESET_NOLNET  = uint256S("3fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),  // nolnet
+                     HARDFORK_POWRESET_BFGTEST = uint256S("007fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),  // bfgtest
                      HARDFORK_POWRESET_REGTEST = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");  // regtestnet
 
 // MVHF-BU-DES-TRIG-10 - config file that is written when forking, and used to detect "forked" condition at start


### PR DESCRIPTION
This PR introduces the BFG test network  (command line option: `-bfgtest`) .

Name: BFG = Bitcoin Forks Genesis 
Motto: "_To boldly fork where no-one has forked before_"
Default P2P Network Port: 19888
Default RPC Port: 19887
Halving interval: as per regular testnet3
POW limit: 0x1d7fffff
Network magic (message start bytes): 0xda 0xe3 0xc7 0xd0
base58Prefixes: same as other public testnets

Rationale: A separate test network is deemed to be a good idea because BTCfork may want to do tests that could be considered disruptive to other networks. We want to be able to do so in relative peace (ok, we cannot prevent others from coming to this network and interfering with our tests, but at least then we're not intruding). Besides, I considered it necessary and fun to learn how to mine a genesis block.

Notes:

- The default fork height has been set to a dummy value (9999999) so that various tests can set their own fork heights using `-forkheight=X` as needed.

- Deployment of SegWit BIPs (141/143/147) has been time-shifted on BFGtest to start on Jan 1st 2017 and end on Mar 3rd 2018. Since this is our own playground, we can decide to start SW a little later, this gives more time for us to do tests before it can activate.

- We may need to reset this test network after some tests - the precise modalities around that are still TBD.

- There are no seed nodes (DNS / static) defined initially. This may change in subsequent code updates.

- as the BFGtest was merged over from MVF-Core, there are some additional commits in this PR where I needed to correct merge omissions.