### PR TITLE
merge of experimental CSIG from MVF-Core (PR#31)

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -148,6 +148,7 @@ testScripts = [ RpcTest(t) for t in [
     'bip68-112-113-p2p',
     'wallet',
     'mvf-bu-retarget --quick', # MVF-BU: quick version for Travis
+    'mvf-bu-csig', # MVF-BU
     'mvf-bu-trig',  # MVF-BU
     'excessive',
     'listtransactions',

--- a/qa/rpc-tests/mvf-bu-csig.py
+++ b/qa/rpc-tests/mvf-bu-csig.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python2
+# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2016 The Bitcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+# MVF-BU
+"""
+Exercise the signature change (replay protection) code.
+Derived from walletbackupauto.py.
+
+Test case is:
+4 nodes - 2 forking and 2 non-forking, sending transactions between each other.
+Prior to the fork, anything goes.
+Post fork, the nodes of the same kind can still send between each other,
+but not to the nodes of the other kind (2 way check).
+"""
+
+import os
+import fnmatch
+import hashlib
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+from random import randint
+import logging
+import time
+
+#logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.INFO)
+
+FORKHEIGHT = 120
+
+class ReplayProtectionTest(BitcoinTestFramework):
+
+    def setup_chain(self):
+        #logging.info("Initializing test directory "+self.options.tmpdir)
+        print("Initializing test directory "+self.options.tmpdir)
+        initialize_chain_clean(self.options.tmpdir, 4)
+
+    def setup_network(self, split=False):
+        #logging.info("Starting nodes")
+        print("Starting nodes")
+
+        # all nodes are spenders, let's give them a keypool=100
+        self.extra_args = [
+            ['-debug', '-whitelist=127.0.0.1', "-keypool=100"],
+            ['-debug', '-whitelist=127.0.0.1', "-keypool=100"],
+            ['-debug', '-whitelist=127.0.0.1', "-keypool=100", "-forkheight=%s"%FORKHEIGHT],
+            ['-debug', '-whitelist=127.0.0.1', "-keypool=100", "-forkheight=%s"%FORKHEIGHT]]
+
+        self.nodes = start_nodes(4, self.options.tmpdir, self.extra_args)
+        connect_nodes(self.nodes[0], 1)
+        connect_nodes(self.nodes[0], 2)
+        connect_nodes(self.nodes[0], 3)
+        connect_nodes(self.nodes[1], 2)
+        connect_nodes(self.nodes[1], 3)
+        connect_nodes(self.nodes[3], 2)
+        self.is_network_split=False
+        self.sync_all()
+
+    def send_and_check(self, from_node, to_node, expect_to_succeed=True, force_sync=True, check=True, check_for_fail=False):
+        ''' try sending 0.1 BTC from one node to another,
+            and optionally check if successful '''
+        to_addr = self.nodes[to_node].getnewaddress()
+        amount = Decimal(1) / Decimal(10)
+        txid = self.nodes[from_node].sendtoaddress(to_addr, amount)
+        if force_sync:
+            sync_mempools([self.nodes[from_node], self.nodes[to_node]])
+        else:
+            time.sleep(1)
+        if check:
+            if check_for_fail:
+                assert_equal(txid in self.nodes[from_node].getrawmempool(), True)
+                assert_equal(txid in self.nodes[to_node].getrawmempool(), False)
+            else:
+                assert_equal(txid in self.nodes[from_node].getrawmempool() and (txid in self.nodes[to_node].getrawmempool() or not expect_to_succeed), True)
+        return txid
+
+    def run_test(self):
+        #logging.info("Fork height configured for block %s"%(FORKHEIGHT))
+        print("Fork height configured for block %s"%(FORKHEIGHT))
+
+        #logging.info("Generating initial 104 blocks")
+        print("Generating initial 104 blocks")
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+        self.nodes[1].generate(1)
+        sync_blocks(self.nodes)
+        self.nodes[2].generate(1)
+        sync_blocks(self.nodes)
+        self.nodes[3].generate(101)
+
+        sync_blocks(self.nodes)
+        #logging.info("Current height %s blocks"%(self.nodes[0].getblockcount()))
+        print("Current height %s blocks"%(self.nodes[0].getblockcount()))
+
+        assert_equal(self.nodes[0].getbalance(), 50)
+        assert_equal(self.nodes[1].getbalance(), 50)
+        assert_equal(self.nodes[2].getbalance(), 50)
+        assert_equal(self.nodes[3].getbalance(), 50)
+
+        assert_equal(self.nodes[0].getblockcount(), 104)
+
+        #logging.info("Check all sending works after setup")
+        print("Check all sending works after setup")
+        # from any node to the others should be ok now
+        # this should generate 4*3 = 12 more blocks
+        for src_node in range(4):
+            for dst_node in range(4):
+                if src_node != dst_node:
+                    #logging.info("... from %d to %d" %(src_node, dst_node))
+                    print("... from %d to %d" %(src_node, dst_node))
+                    self.send_and_check(src_node, dst_node, True)
+                    self.nodes[dst_node].generate(1)
+                    sync_blocks(self.nodes)
+
+        current_height = self.nodes[0].getblockcount()
+        assert_equal(current_height, 116)
+
+        # generate blocks, one on each node in turn, until we reach pre-fork block height
+        blocks_to_fork = FORKHEIGHT - current_height - 1
+        self.nodes[0].generate(blocks_to_fork)
+
+        # not sure why this loop didn't work reliably...
+        # maybe it was the round-robin generation
+        while False: #blocks_to_fork > 0:
+            #logging.info("blocks left to fork height: %d" % blocks_to_fork)
+            print("blocks left to fork height: %d" % blocks_to_fork)
+            self.nodes[blocks_to_fork % 4].generate(1)
+            blocks_to_fork -= 1
+
+        sync_blocks(self.nodes)
+        assert_equal(self.nodes[0].getblockcount(), FORKHEIGHT - 1)
+
+        #logging.info("Current height %s blocks (pre-fork block)"%(self.nodes[0].getblockcount()))
+        print("Current height %s blocks (pre-fork block)"%(self.nodes[0].getblockcount()))
+
+        # check that we can still send to all other nodes for the pre-fork block
+
+        # collect a bunch of tx's sent by the nodes to each other
+        #logging.info("sending tx's between all nodes at pre-fork")
+        print("sending tx's between all nodes at pre-fork")
+        should_be_fine_txs = []
+        for src_node in range(4):
+            for dst_node in range(4):
+                if src_node != dst_node:
+                    #logging.info("... from %d to %d" %(src_node, dst_node))
+                    print("... from %d to %d" %(src_node, dst_node))
+                    should_be_fine_txs.append(self.send_and_check(src_node, dst_node, True))
+
+        #logging.info("Verifying tx's were still accepted by all nodes")
+        print("Verifying tx's were still accepted by all nodes")
+        sync_mempools(self.nodes)
+        mempools = [self.nodes[i].getrawmempool() for i in range(4)]
+        for tx in should_be_fine_txs:
+            for n in range(4):
+                assert_equal(tx in mempools[n], True)
+
+        # generate the fork block
+        #logging.info("Generate fork block at height %s" % FORKHEIGHT)
+        print("Generate fork block at height %s" % FORKHEIGHT)
+        self.nodes[0].generate(1)
+
+        # check the previous round of tx's not in mempool anymore
+        self.sync_all()
+        assert_equal(self.nodes[0].getblockcount(), FORKHEIGHT)
+
+        #logging.info("Verifying tx's no longer in any mempool")
+        print("Verifying tx's no longer in any mempool")
+        mempools = [self.nodes[i].getrawmempool() for i in range(4)]
+        for tx in should_be_fine_txs:
+            for n in range(4):
+                assert_equal(tx in mempools[n], False)
+
+        # check that now, only nodes of the same kind can transact
+        # these pairs should work fine
+        #logging.info("Checking transactions between same-kind nodes")
+        print("Checking transactions between same-kind nodes")
+        for pair in ((0,1), (1,0), (2,3), (3,2)):
+            #logging.info("... from %d to %d" %(pair[0], pair[1]))
+            print("... from %d to %d" %(pair[0], pair[1]))
+            self.send_and_check(pair[0], pair[1], True)
+
+        # re-connect the nodes which have been disconnected due to the
+        # above post-fork transactions, so we can test them separately
+        #logging.info("Re-connecting nodes which disconnected due to prior step")
+        print("Re-connecting nodes which disconnected due to prior step")
+        connect_nodes_bi(self.nodes,0,2)
+        connect_nodes_bi(self.nodes,0,3)
+        connect_nodes_bi(self.nodes,1,2)
+        connect_nodes_bi(self.nodes,1,3)
+        #logging.info("Checking transactions between forked/unforked nodes")
+        print("Checking transactions between forked/unforked nodes")
+        # these should not work anymore
+
+
+        # MVF-BU TODO: decide whether to accept old-style signatures post-fork (maybe limited-time only?)
+        # if you only want to deny new->old, then use the commented out code
+        #for pair in ((2,0), (2,1), (3,0), (3,1)):
+
+        # check both forked->unforked and vice versa are blocked now
+        for pair in ((0,2), (0,3), (1,2), (1,3), (2,0), (2,1), (3,0), (3,1)):
+            #logging.info("... from %d to %d" %(pair[0], pair[1]))
+            print("... from %d to %d" %(pair[0], pair[1]))
+            self.send_and_check(pair[0], pair[1], expect_to_succeed=False, force_sync=False, check=True, check_for_fail=True)
+
+if __name__ == '__main__':
+    ReplayProtectionTest().main()

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -26,7 +26,7 @@ from .authproxy import AuthServiceProxy, JSONRPCException
 COVERAGE_DIR = None
 
 # MVF-BU begin read regtest fork params from C files
-_mvf_common_h_fh = open('src/mvf-bu.h', 'rt')
+_mvf_common_h_fh = open('src/mvf-bu-globals.h', 'rt')
 _mvf_common_h_contents = _mvf_common_h_fh.read()
 _mvf_common_h_fh.close()
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -119,6 +119,7 @@ BITCOIN_CORE_H = \
   merkleblock.h \
   miner.h \
   mvf-bu.h \
+  mvf-bu-globals.h \
   mvf-btcfork_conf_parser.h \
   net.h \
   leakybucket.h \
@@ -297,6 +298,7 @@ libbitcoin_common_a_SOURCES = \
   key.cpp \
   keystore.cpp \
   netbase.cpp \
+  mvf-bu-globals.cpp \
   primitives/block.cpp \
   primitives/transaction.cpp \
   protocol.cpp \
@@ -426,6 +428,7 @@ libbitcoinconsensus_la_SOURCES = \
   hash.cpp \
   primitives/transaction.cpp \
   pubkey.cpp \
+  mvf-bu-globals.cpp \
   script/bitcoinconsensus.cpp \
   script/interpreter.cpp \
   script/script.cpp \

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -17,6 +17,7 @@
 #include "sync.h"
 #include "utilmoneystr.h"
 #include "utilstrencodings.h"
+#include "mvf-bu.h"  // MVF-BU added
 
 #include <stdio.h>
 
@@ -364,6 +365,8 @@ vector<unsigned char> ParseHexUO(map<string,UniValue>& o, string strKey)
 
 static void MutateTxSign(CMutableTransaction& tx, const string& flagStr)
 {
+    // MVF-BU TODO: check if this function needs adaptation to be able to produce forked signatures
+
     int nHashType = SIGHASH_ALL;
 
     if (flagStr.size() > 0)

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -156,7 +156,10 @@ bool AppInit(int argc, char* argv[])
         // Set this early so that parameter interactions go to console
         InitLogging();
         InitParameterInteraction();
-        ForkSetup(Params());  // MVF-BU
+        // MVF-BU begin
+        if (!ForkSetup(Params()))
+            StartShutdown();
+        // MVF-BU end
         fRet = AppInit2(threadGroup, scheduler);
     }
     catch (const std::exception& e) {

--- a/src/mvf-bu-globals.cpp
+++ b/src/mvf-bu-globals.cpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2016 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// MVF-BU common objects and functions
+
+#include "mvf-bu-globals.h"
+
+using namespace std;
+
+// key-value maps for btcfork.conf configuration items
+map<string, string> btcforkMapArgs;
+map<string, vector<string> > btcforkMapMultiArgs;
+
+// version string identifying the consensus-relevant algorithmic changes
+// so that a user can quickly see if MVF fork clients are compatible
+// for test purposes (since they may diverge during development/testing).
+// A new value must be chosen whenever there are changes to consensus
+// relevant functionality (excepting things which are parameterized).
+// Values are surnames chosen from the name list of space travelers at
+// https://en.wikipedia.org/wiki/List_of_space_travelers_by_name
+// already used: AKIYAMA (add current one to the list when replacing)
+std::string post_fork_consensus_id = "YAMAZAKI";
+
+// actual fork height, taking into account user configuration parameters (MVHF-BU-DES-TRIG-4)
+int FinalActivateForkHeight = 0;
+
+// actual difficulty drop factor, taking into account user configuration parameters (MVF-BU TODO: MVHF-BU-DES-DIAD-?)
+unsigned FinalDifficultyDropFactor = 0;
+// actual fork id, taking into account user configuration parameters (MVHF-BU-DES-CSIG-1)
+int FinalForkId = 0;
+
+// track whether HF has been activated before in previous run (MVHF-BU-DES-TRIG-5)
+// is set at startup based on btcfork.conf presence
+bool wasMVFHardForkPreviouslyActivated = false;
+
+// track whether HF is active (MVHF-BU-DES-TRIG-5)
+bool isMVFHardForkActive = false;
+
+// track whether auto wallet backup might still need to be done
+// this is set to true at startup if client detects fork already triggered
+// otherwise when the backup is made. (MVHF-BU-DES-WABU-1)
+bool fAutoBackupDone = false;
+
+// default suffix to append to wallet filename for auto backup (MVHF-BU-DES-WABU-1)
+std::string autoWalletBackupSuffix = "auto.@.bak";
+

--- a/src/mvf-bu-globals.h
+++ b/src/mvf-bu-globals.h
@@ -1,0 +1,107 @@
+// Copyright (c) 2016 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// MVF-BU common declarations
+#pragma once
+#ifndef BITCOIN_MVF_BU_GLOBALS_H
+#define BITCOIN_MVF_BU_GLOBALS_H
+
+#include "protocol.h"
+
+// MVHF-BU-DES-TRIG-10 - config file that is written when forking, and used to detect "forked" condition at start
+const char * const BTCFORK_CONF_FILENAME = "btcfork.conf";
+
+extern int FinalActivateForkHeight;             // MVHF-BU-DES-TRIG-4
+extern unsigned FinalDifficultyDropFactor;      // MVF-BU TODO: MVHF-BU-DES-DIAD-?
+extern bool wasMVFHardForkPreviouslyActivated;  // MVHF-BU-DES-TRIG-5
+extern bool isMVFHardForkActive;                // MVHF-BU-DES-TRIG-5
+extern int FinalForkId;                         // MVHF-BU-DES-CSIG-1
+extern bool fAutoBackupDone;                    // MVHF-BU-DES-WABU-1
+extern std::string autoWalletBackupSuffix;      // MVHF-BU-DES-WABU-1
+
+// btcfork.conf configuration key-value maps (MVF TODO: reference associated design)
+extern std::map<std::string, std::string> btcforkMapArgs;
+extern std::map<std::string, std::vector<std::string> > btcforkMapMultiArgs;
+
+// version string identifying the consensus-relevant algorithmic changes
+// so that a user can quickly see if fork clients are compatible
+extern std::string post_fork_consensus_id;
+
+// CAUTION! certain constant definitions from this file are parsed
+// and extracted by the Python test framework (util.py).
+// Usually there should be notes documenting where values have to
+// respect a certain format, but please tread carefully with the
+// formatting and do not just refactor the C++ names without
+// modifying the Python code.
+
+// default values that can be easily put into an enum
+enum {
+// MVHF-BU-DES-TRIG-1 - trigger related parameter defaults
+// MVF-BU TODO: choose values with some consideration instead of dummy values
+// must be digit-only numerals (no operators) since they are read in by Python test framework
+HARDFORK_HEIGHT_MAINNET =  666666,   // operational network trigger height
+HARDFORK_HEIGHT_TESTNET = 9999999,   // public test network trigger height
+HARDFORK_HEIGHT_NOLNET  = 8888888,   // BU public no-limit test network  trigger height
+HARDFORK_HEIGHT_REGTEST = 9999999,   // regression test network (local)  trigger height
+HARDFORK_HEIGHT_BFGTEST = 9999999,   // btcforks genesis test network trigger height
+
+// MVHF-BU-DES-DIAD-3 / MVHF-BU-DES-DIAD-4
+// period (in blocks) from fork activation until retargeting returns to normal
+HARDFORK_RETARGET_BLOCKS = 180*144,    // number of blocks during which special fork retargeting is active
+// default drop factors for various networks (MVF-BU TODO: design reference)
+// must be digit-only numerals  (no operators) since they are read in by Python test framework
+MAX_HARDFORK_DROPFACTOR = 1000000,     // maximum drop factor
+HARDFORK_DROPFACTOR_MAINNET = 100000,  // default difficulty drop on operational network (mainnet)
+HARDFORK_DROPFACTOR_TESTNET = 10000,   // default difficulty drop on public test network (testnet)
+HARDFORK_DROPFACTOR_NOLNET = 10000,    // default difficulty drop on BU public no-limit test network (nolnet)
+HARDFORK_DROPFACTOR_REGTEST = 4,       // default difficulty drop on local regression test network (regtestnet)
+HARDFORK_DROPFACTOR_BFGTEST = 1000,    // default difficulty drop on btcforks genesis test network (bfgtest)
+
+// MVHF-BU-DES-NSEP-1 - network separation parameter defaults
+// MVF-BU TODO: re-check that these port values could be used
+// must be digit-only numerals (no operators) since they are read in by Python test framework
+HARDFORK_PORT_MAINNET = 9442,        // default post-fork port on operational network (mainnet)
+HARDFORK_PORT_TESTNET = 9443,        // default post-fork port on public test network (testnet)
+HARDFORK_PORT_NOLNET  = 9444,        // default post-fork port on BU public no-limit test network (nolnet)
+HARDFORK_PORT_REGTEST = 19555,       // default post-fork port on local regression test network (regtestnet)
+HARDFORK_PORT_BFGTEST = 19988,       // default post-fork port on btcforks genesis test network (bfgtest)
+
+// MVHF-BU-DES-CSIG-1 - signature change parameter defaults
+// must be hex numerals (0x prefix) since they are read in and converted from hex by Python test framework
+HARDFORK_SIGHASH_ID = 0x777000,      // 3 byte fork id that is left-shifted by 8 bits and then ORed with the SIGHASHes
+MAX_HARDFORK_SIGHASH_ID = 0xFFFFFF,  // fork id may not exceed maximum representable in 3 bytes
+};
+
+// MVHF-BU-DES-NSEP-1 - network separation parameter defaults
+// message start strings (network magic) after forking
+// The message start string should be designed to be unlikely to occur in normal data.
+// The characters are rarely used upper ASCII, not valid as UTF-8, and produce
+// a large 32-bit integer with any alignment.
+// MVF-BU TODO: Assign new netmagic values
+// MVF-BU TODO: Clarify why it's ok for testnet to deviate from the above rationale.
+//              One would expect regtestnet to be less important than a public network!
+static const CMessageHeader::MessageStartChars pchMessageStart_HardForkMainnet  = { 0xf9, 0xbe, 0xb4, 0xd9 },
+                                               pchMessageStart_HardForkNolnet   = { 0xfa, 0xce, 0xc4, 0xe9 },
+                                               pchMessageStart_HardForkTestnet  = { 0x0b, 0x11, 0x09, 0x07 },
+                                               pchMessageStart_HardForkRegtest  = { 0xf9, 0xbe, 0xb4, 0xd9 };
+
+// MVHF-BU-DES-DIAD-1 - difficulty adjustment parameter defaults
+// MVF-Core TODO: calibrate the values for public testnets according to estimated initial present hashpower
+// values to which powLimit is reset at fork time on various networks (MVHF-BU-DES-DIAD-2):
+static const uint256 HARDFORK_POWRESET_MAINNET = uint256S("00007fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),  // mainnet
+                     HARDFORK_POWRESET_TESTNET = uint256S("007fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),  // testnet
+                     HARDFORK_POWRESET_NOLNET  = uint256S("3fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),  // nolnet
+                     HARDFORK_POWRESET_BFGTEST = uint256S("007fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),  // bfgtest
+                     HARDFORK_POWRESET_REGTEST = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");  // regtestnet
+
+// MVHF-BU-DES-DIAD-? -force-retarget option determines  whether to actively retarget on regtest after fork happens
+// (not all tests need that, so the POW/difficulty fork related ones that do specifically invoke this option)
+const bool DEFAULT_FORCE_RETARGET = false;
+
+// default value for -nosegwitfork option to disable the fork trigger on SegWit activation
+// caution: -noX options are turned into -X=0 by util.cpp, therefore the
+// parameter must be accessed as '-segwitfork' and the default below pertains
+// to that.
+const bool DEFAULT_TRIGGER_ON_SEGWIT = true;
+
+#endif

--- a/src/mvf-bu.h
+++ b/src/mvf-bu.h
@@ -9,109 +9,13 @@
 
 #include <boost/filesystem.hpp>
 
-#include "protocol.h"
+#include "mvf-bu-globals.h"
 
 class CChainParams;
 
-// MVHF-BU-DES-TRIG-10 - config file that is written when forking, and used to detect "forked" condition at start
-const char * const BTCFORK_CONF_FILENAME = "btcfork.conf";
-
-// btcfork.conf configuration key-value maps (MVF TODO: reference associated design)
-extern std::map<std::string, std::string> btcforkMapArgs;
-extern std::map<std::string, std::vector<std::string> > btcforkMapMultiArgs;
-
-extern int FinalActivateForkHeight;             // MVHF-BU-DES-TRIG-4
-extern unsigned FinalDifficultyDropFactor;      // MVF-BU TODO: MVHF-BU-DES-DIAD-?
-extern bool wasMVFHardForkPreviouslyActivated;  // MVHF-BU-DES-TRIG-5
-extern bool isMVFHardForkActive;                // MVHF-BU-DES-TRIG-5
-extern int FinalForkId;                         // MVHF-BU-DES-CSIG-1
-extern bool fAutoBackupDone;                    // MVHF-BU-DES-WABU-1
-extern std::string autoWalletBackupSuffix;      // MVHF-BU-DES-WABU-1
-
-// version string identifying the consensus-relevant algorithmic changes
-// so that a user can quickly see if fork clients are compatible
-extern std::string post_fork_consensus_id;
-
-// CAUTION! certain constant definitions from this file are parsed
-// and extracted by the Python test framework (util.py).
-// Usually there should be notes documenting where values have to
-// respect a certain format, but please tread carefully with the
-// formatting and do not just refactor the C++ names without
-// modifying the Python code.
-
-// default values that can be easily put into an enum
-enum {
-// MVHF-BU-DES-TRIG-1 - trigger related parameter defaults
-// MVF-BU TODO: choose values with some consideration instead of dummy values
-// must be digit-only numerals (no operators) since they are read in by Python test framework
-HARDFORK_HEIGHT_MAINNET =  666666,   // operational network trigger height
-HARDFORK_HEIGHT_TESTNET = 9999999,   // public test network trigger height
-HARDFORK_HEIGHT_NOLNET  = 8888888,   // BU public no-limit test network  trigger height
-HARDFORK_HEIGHT_REGTEST = 9999999,   // regression test network (local)  trigger height
-HARDFORK_HEIGHT_BFGTEST = 9999999,   // btcforks genesis test network trigger height
-
-// MVHF-BU-DES-DIAD-3 / MVHF-BU-DES-DIAD-4
-// period (in blocks) from fork activation until retargeting returns to normal
-HARDFORK_RETARGET_BLOCKS = 180*144,    // MVF-BU TODO: Revert after testing to 180*144 (25920) blocks
-// default drop factors for various networks (MVF-BU TODO: design reference)
-// must be digit-only numerals  (no operators) since they are read in by Python test framework
-MAX_HARDFORK_DROPFACTOR = 1000000,     // maximum drop factor
-HARDFORK_DROPFACTOR_MAINNET = 100000,  // default difficulty drop on operational network (mainnet)
-HARDFORK_DROPFACTOR_TESTNET = 10000,   // default difficulty drop on public test network (testnet)
-HARDFORK_DROPFACTOR_NOLNET = 10000,    // default difficulty drop on BU public no-limit test network (nolnet)
-HARDFORK_DROPFACTOR_REGTEST = 4,       // default difficulty drop on local regression test network (regtestnet)
-HARDFORK_DROPFACTOR_BFGTEST = 1000,    // default difficulty drop on btcforks genesis test network (bfgtest)
-
-// MVHF-BU-DES-NSEP-1 - network separation parameter defaults
-// MVF-BU TODO: re-check that these port values could be used
-// must be digit-only numerals (no operators) since they are read in by Python test framework
-HARDFORK_PORT_MAINNET = 9442,        // default post-fork port on operational network (mainnet)
-HARDFORK_PORT_TESTNET = 9443,        // default post-fork port on public test network (testnet)
-HARDFORK_PORT_NOLNET  = 9444,        // default post-fork port on BU public no-limit test network (nolnet)
-HARDFORK_PORT_REGTEST = 19555,       // default post-fork port on local regression test network (regtestnet)
-HARDFORK_PORT_BFGTEST = 19988,       // default post-fork port on btcforks genesis test network (bfgtest)
-
-// MVHF-BU-DES-CSIG-1 - signature change parameter defaults
-// must be hex numerals (0x prefix) since they are read in and converted from hex by Python test framework
-HARDFORK_SIGHASH_ID = 0x777000,      // 3 byte fork id that is left-shifted by 8 bits and then ORed with the SIGHASHes
-MAX_HARDFORK_SIGHASH_ID = 0xFFFFFF,  // fork id may not exceed maximum representable in 3 bytes
-};
-
-// MVHF-BU-DES-NSEP-1 - network separation parameter defaults
-// message start strings (network magic) after forking
-// The message start string should be designed to be unlikely to occur in normal data.
-// The characters are rarely used upper ASCII, not valid as UTF-8, and produce
-// a large 32-bit integer with any alignment.
-// MVF-BU TODO: Assign new netmagic values
-// MVF-BU TODO: Clarify why it's ok for testnet to deviate from the above rationale.
-//              One would expect regtestnet to be less important than a public network!
-static const CMessageHeader::MessageStartChars pchMessageStart_HardForkMainnet  = { 0xf9, 0xbe, 0xb4, 0xd9 },
-                                               pchMessageStart_HardForkNolnet   = { 0xfa, 0xce, 0xc4, 0xe9 },
-                                               pchMessageStart_HardForkTestnet  = { 0x0b, 0x11, 0x09, 0x07 },
-                                               pchMessageStart_HardForkRegtest  = { 0xf9, 0xbe, 0xb4, 0xd9 };
-
-// MVHF-BU-DES-DIAD-1 - difficulty adjustment parameter defaults
-// MVF-BU TODO: calibrate the values for public testnets according to estimated initial present hashpower
-// values to which powLimit is reset at fork time on various networks (MVHF-BU-DES-DIAD-2):
-static const uint256 HARDFORK_POWRESET_MAINNET = uint256S("00007fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),  // mainnet
-                     HARDFORK_POWRESET_TESTNET = uint256S("007fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),  // testnet
-                     HARDFORK_POWRESET_NOLNET  = uint256S("3fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),  // nolnet
-                     HARDFORK_POWRESET_BFGTEST = uint256S("007fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),  // bfgtest
-                     HARDFORK_POWRESET_REGTEST = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");  // regtestnet
-
-// MVHF-BU-DES-DIAD-? -force-retarget option determines  whether to actively retarget on regtest after fork happens
-// (not all tests need that, so the POW/difficulty fork related ones that do specifically invoke this option)
-const bool DEFAULT_FORCE_RETARGET = false;
-
-// default value for -nosegwitfork option to disable the fork trigger on SegWit activation
-// caution: -noX options are turned into -X=0 by util.cpp, therefore the
-// parameter must be accessed as '-segwitfork' and the default below pertains
-// to that.
-const bool DEFAULT_TRIGGER_ON_SEGWIT = true;
-
 extern std::string ForkCmdLineHelp();  // fork-specific command line option help (MVHF-BU-DES-TRIG-8)
 extern boost::filesystem::path MVFGetConfigFile();  // get the full path to the btcfork.conf file
-extern void ForkSetup(const CChainParams& chainparams);  // actions to perform at program setup (parameter validation etc.)
+extern bool ForkSetup(const CChainParams& chainparams);  // actions to perform at program setup (parameter validation etc.)
 extern void ActivateFork(int actualForkHeight, bool doBackup=true);  // actions to perform at fork triggering (MVHF-BU-DES-TRIG-6)
 extern void DeactivateFork(void);  // actions to revert if reorg deactivates fork (MVHF-BU-DES-TRIG-7)
 extern std::string MVFexpandWalletAutoBackupPath(const std::string& strDest, const std::string& strWalletFile, int BackupBlock, bool createDirs=true); // returns the finalized path of the auto wallet backup file (MVHF-BU-DES-WABU-2)

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -666,7 +666,10 @@ int main(int argc, char *argv[])
         app.createSplashScreen(networkStyle.data());
 
     UnlimitedSetup();
-    ForkSetup(Params());  // MVF-BU
+    // MVF-BU begin
+    if (!ForkSetup(Params()))
+        StartShutdown();
+    // MVF-BU end
 
     try
     {

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -1,6 +1,7 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2015 The Bitcoin Core developers
 // Copyright (c) 2015-2016 The Bitcoin Unlimited developers
+// Copyright (c) 2016 The Bitcoin developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -91,7 +92,9 @@ enum
 
 bool CheckSignatureEncoding(const std::vector<unsigned char> &vchSig, unsigned int flags, ScriptError* serror);
 
-uint256 SignatureHash(const CScript &scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType);
+// MVF-BU begin CSIG extend with chain id
+uint256 SignatureHash(const CScript &scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType, unsigned int nChainId=0);
+// MVF-BU end
 
 class BaseSignatureChecker
 {

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2015 The Bitcoin Core developers
 // Copyright (c) 2015-2016 The Bitcoin Unlimited developers
+// Copyright (c) 2016 The Bitcoin developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -12,6 +13,7 @@
 #include "primitives/transaction.h"
 #include "script/standard.h"
 #include "uint256.h"
+#include "mvf-bu-globals.h"  // MVF-BU added
 
 #include <boost/foreach.hpp>
 
@@ -27,7 +29,13 @@ bool TransactionSignatureCreator::CreateSig(std::vector<unsigned char>& vchSig, 
     if (!keystore->GetKey(address, key))
         return false;
 
-    uint256 hash = SignatureHash(scriptCode, *txTo, nIn, nHashType);
+    // MVF-BU begin CSIG
+    uint256 hash;
+    if (isMVFHardForkActive)
+        hash = SignatureHash(scriptCode, *txTo, nIn, nHashType, FinalForkId);
+    else
+        hash = SignatureHash(scriptCode, *txTo, nIn, nHashType);
+    // MVF-BU end
     if (!key.Sign(hash, vchSig))
         return false;
     vchSig.push_back((unsigned char)nHashType);


### PR DESCRIPTION
This PR delivers a "strict" implementation of signature change which considers pre-fork signatures invalid after the fork (in line with the current MVF requirement specification).

The impacts of this will need to be studied on the new test network (bfgtest), and further changes are very likely.

NOTE: the default "forkid" (a.k.a. chain id) - the number which post-fork modifies the transaction signatures, is different between MVF-BU (0x777000) and MVF-Core (0x555000).
This means MVF-BU and MVF-Core will diverge even if they both fork off at the same height, unless they are explicitly put on the same forkid (using `-forkid=X` option). This is on purpose.