### PR TITLE
add missing network style for bfgtest network

### DIFF
--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -51,5 +51,6 @@ static const int MAX_URI_LENGTH = 255;
 #define QAPP_ORG_DOMAIN "bitcoin.org"
 #define QAPP_APP_NAME_DEFAULT "Bitcoin-Qt"
 #define QAPP_APP_NAME_TESTNET "Bitcoin-Qt-testnet"
+#define QAPP_APP_NAME_BFGTEST "Bitcoin-Qt-bfgtest"  // MVF-BU added (MVF-BU TODO: reference to design)
 
 #endif // BITCOIN_QT_GUICONSTANTS_H

--- a/src/qt/networkstyle.cpp
+++ b/src/qt/networkstyle.cpp
@@ -18,6 +18,7 @@ static const struct {
 } network_styles[] = {
     {"main", QAPP_APP_NAME_DEFAULT, 0, 0, ""},
     {"test", QAPP_APP_NAME_TESTNET, 70, 30, QT_TRANSLATE_NOOP("SplashScreen", "[testnet]")},
+    {"bfgtest", QAPP_APP_NAME_BFGTEST, 70, 30, QT_TRANSLATE_NOOP("SplashScreen", "[bfgtest]")},  // MVF-BU added  (MVF-BU TODO: reference to design)
     {"regtest", QAPP_APP_NAME_TESTNET, 160, 30, "[regtest]"}
 };
 static const unsigned network_styles_count = sizeof(network_styles)/sizeof(*network_styles);


### PR DESCRIPTION
bitcoin-qt coredumps due to an assert if started with a network is lacking an entry in network_styles.

First fixed on MVF-Core here: https://github.com/BTCfork/hardfork_prototype_1_mvf-core/pull/33

A similar fix has been submitted for upstream BU where 'nol' network was missing in the GUI definitions - see BU PR# https://github.com/BitcoinUnlimited/BitcoinUnlimited/pull/200 .
Addition of 'nol' support for the GUI will depend if that PR is merged upstream.