### PR TITLE
Move tests to extended suite to debug Travis build timeouts

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -167,12 +167,10 @@ if ENABLE_ZMQ:
 #Tests
 testScripts = [ RpcTest(t) for t in [
     'bip68-112-113-p2p',
-    'parallel',
     'wallet',
     'mvf-bu-retarget --quick', # MVF-BU: quick version for Travis
     'mvf-bu-csig', # MVF-BU
     'mvf-bu-trig',  # MVF-BU
-    'excessive',
     'listtransactions',
     'receivedby',
     'mempool_resurrect_test',
@@ -210,6 +208,7 @@ testScripts = [ RpcTest(t) for t in [
 ] ]
 
 testScriptsExt = [ RpcTest(t) for t in [
+    'parallel',
     'txPerf',
     'excessive --extended',
     'bip9-softforks',


### PR DESCRIPTION
A Travis build that worked on PR branch failed after merge to master,
with two jobs persistently timing out.

Parallel and excessive seem to be the longest tests, and have been
temporarily moved to the extended section.
They can remain there for a while (at least until next merges from upstream),
but need to be brought back eventually.