### PR TITLE
Fix bip68-sequence test

### DIFF
--- a/qa/rpc-tests/bip68-sequence.py
+++ b/qa/rpc-tests/bip68-sequence.py
@@ -27,8 +27,8 @@ class BIP68Test(BitcoinTestFramework):
 
     def setup_network(self):
         self.nodes = []
-        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug", "-blockprioritysize=0"]))
-        self.nodes.append(start_node(1, self.options.tmpdir, ["-debug", "-blockprioritysize=0", "-acceptnonstdtxn=0"]))
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-whitelist=127.0.0.1", "-debug", "-blockprioritysize=0"]))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-whitelist=127.0.0.1", "-debug", "-blockprioritysize=0", "-acceptnonstdtxn=0"]))
         self.is_network_split = False
         self.relayfee = self.nodes[0].getnetworkinfo()["relayfee"]
         connect_nodes(self.nodes[0], 1)

--- a/qa/rpc-tests/test_framework/nodemessages.py
+++ b/qa/rpc-tests/test_framework/nodemessages.py
@@ -6,6 +6,8 @@ from binascii import hexlify, unhexlify
 import time
 from codecs import encode
 from threading import RLock
+from io import BytesIO
+
 MY_VERSION = 60001  # past bip-31 for ping/pong
 MY_SUBVERSION = b"/python-mininode-tester:0.0.3/"
 


### PR DESCRIPTION
As per https://github.com/BitcoinUnlimited/BitcoinUnlimited/pull/628

node0 was banning node1 if the whitelisting was not applied.